### PR TITLE
add a generic Tile transformation; like numpy.tile

### DIFF
--- a/environment_cpu.yaml
+++ b/environment_cpu.yaml
@@ -9,7 +9,6 @@ dependencies:
     - cpuonly
     - elf
     - pip
-    - pytest
     - pytorch
     - tensorboard
     - tifffile

--- a/environment_cpu.yaml
+++ b/environment_cpu.yaml
@@ -5,10 +5,11 @@ channels:
 name:
     torch-em-cpu
 dependencies:
+    - affogato
     - cpuonly
     - elf
-    - affogato
     - pip
+    - pytest
     - pytorch
     - tensorboard
     - tifffile

--- a/environment_gpu.yaml
+++ b/environment_gpu.yaml
@@ -9,7 +9,6 @@ dependencies:
     - cudatoolkit=10.2  # set correct cuda version for your system
     - elf
     - pip
-    - pytest
     - pytorch
     - tensorboard
     - tifffile

--- a/environment_gpu.yaml
+++ b/environment_gpu.yaml
@@ -5,14 +5,15 @@ channels:
 name:
     torch-em
 dependencies:
+    - affogato
     - cudatoolkit=10.2  # set correct cuda version for your system
     - elf
-    - affogato
     - pip
+    - pytest
     - pytorch
     - tensorboard
-    - torchvision
     - tifffile
+    - torchvision
     - tqdm
     - pip:
         - kornia

--- a/test/transform/test_generic.py
+++ b/test/transform/test_generic.py
@@ -1,0 +1,28 @@
+import numpy
+import torch
+import pytest
+
+from torch_em.transform import Tile
+
+
+@pytest.mark.parametrize("ndim,reps", [(1, (4, 2)), (2, (4, 2)), (3, (4, 2))])
+def test_tile(ndim, reps):
+    tile_aug = Tile(reps, match_shape_exactly=len(reps) == ndim)
+    test_shape = [2, 3, 4][:ndim]
+    data = numpy.random.random(test_shape)
+
+    x = torch.tensor(data)
+
+    expected = numpy.tile(x.numpy(), reps)
+    if len(reps) == ndim:
+        expected_torch = x.repeat(*reps)
+        assert expected.shape == expected_torch.shape
+
+    actual = tile_aug(x)
+
+    assert actual.shape == expected.shape
+
+    a = numpy.array(data)
+
+    actual = tile_aug(a)
+    assert actual.shape == expected.shape

--- a/test/transform/test_generic.py
+++ b/test/transform/test_generic.py
@@ -1,28 +1,36 @@
 import numpy
 import torch
-import pytest
 
 from torch_em.transform import Tile
 
 
-@pytest.mark.parametrize("ndim,reps", [(1, (4, 2)), (2, (4, 2)), (3, (4, 2))])
-def test_tile(ndim, reps):
-    tile_aug = Tile(reps, match_shape_exactly=len(reps) == ndim)
-    test_shape = [2, 3, 4][:ndim]
-    data = numpy.random.random(test_shape)
+from unittest import TestCase
 
-    x = torch.tensor(data)
 
-    expected = numpy.tile(x.numpy(), reps)
-    if len(reps) == ndim:
-        expected_torch = x.repeat(*reps)
-        assert expected.shape == expected_torch.shape
+class TestTile(TestCase):
+    def test_tile(self):
+        for ndim, reps in [(1, (4, 2)), (2, (4, 2)), (3, (4, 2))]:
+            with self.subTest():
+                self._test_tile_impl(ndim, reps)
 
-    actual = tile_aug(x)
+    @staticmethod
+    def _test_tile_impl(ndim, reps):
+        tile_aug = Tile(reps, match_shape_exactly=len(reps) == ndim)
+        test_shape = [2, 3, 4][:ndim]
+        data = numpy.random.random(test_shape)
 
-    assert actual.shape == expected.shape
+        x = torch.tensor(data)
 
-    a = numpy.array(data)
+        expected = numpy.tile(x.numpy(), reps)
+        if len(reps) == ndim:
+            expected_torch = x.repeat(*reps)
+            assert expected.shape == expected_torch.shape
 
-    actual = tile_aug(a)
-    assert actual.shape == expected.shape
+        actual = tile_aug(x)
+
+        assert actual.shape == expected.shape
+
+        a = numpy.array(data)
+
+        actual = tile_aug(a)
+        assert actual.shape == expected.shape

--- a/torch_em/transform/__init__.py
+++ b/torch_em/transform/__init__.py
@@ -1,3 +1,4 @@
 from .augmentation import get_augmentations
+from .generic import Tile
 from .label import AffinityTransform, BoundaryTransform, labels_to_binary
 from .raw import get_raw_transform, EMDefectAugmentation

--- a/torch_em/transform/generic.py
+++ b/torch_em/transform/generic.py
@@ -1,0 +1,29 @@
+from typing import Any, Dict, Optional, Sequence, Union
+
+import numpy
+import torch
+
+
+class Tile(torch.nn.Module):
+    _params = None
+    def __init__(self, reps: Sequence[int] = (2,), match_shape_exactly: bool = True):
+        super().__init__()
+        self.reps = reps
+        self.match_shape_exactly = match_shape_exactly
+
+    def forward(self, input: Union[torch.Tensor, numpy.ndarray], params: Optional[Dict[str, Any]] = None):
+        assert not self.match_shape_exactly or len(input.shape) == len(self.reps), (input.shape, self.reps)
+        if isinstance(input, torch.Tensor):
+            # return torch.tile(input, self.reps)  # todo: use torch.tile (for pytorch >=1.8?)
+            reps = list(self.reps)
+            for _ in range(max(0, len(input.shape) - len(reps))):
+                reps.insert(0, 1)
+
+            for _ in range(max(0, len(reps) - len(input.shape))):
+                input = input.unsqueeze(0)
+
+            return input.repeat(*reps)
+        elif isinstance(input, numpy.ndarray):
+            return numpy.tile(input, self.reps)
+        else:
+            raise NotImplementedError(type(input))


### PR DESCRIPTION
Not sure about the preferred way to add a dimension agnostic transformation.

This `class Tile(torch.nn.Module)` implementation does not inherite from a kornia class (as there is no public common base class for 2D/3D), but is compatible with them.. maybe there should be an abstract base class for these cases...
 