### PR TITLE
Wandb logger

### DIFF
--- a/torch_em/segmentation.py
+++ b/torch_em/segmentation.py
@@ -1,7 +1,7 @@
 import os
 from glob import glob
 
-import torch
+import torch.utils.data
 from elf.io import open_file
 
 from .data import ConcatDataset, ImageCollectionDataset, SegmentationDataset

--- a/torch_em/segmentation.py
+++ b/torch_em/segmentation.py
@@ -1,6 +1,7 @@
 import os
 from glob import glob
 
+import torch
 import torch.utils.data
 from elf.io import open_file
 

--- a/torch_em/trainer/wandb_logger.py
+++ b/torch_em/trainer/wandb_logger.py
@@ -31,7 +31,7 @@ class WandbLogger:
 
         if trainer.name is None:
             if os.environ.get("WANDB_MODE") == "offline":
-                trainer.name = f"offline-{datetime.now()}"
+                trainer.name = f"offline_{datetime.now():%Y-%m-%d_%H-%M-%S}"
             else:
                 trainer.name = self.wand_run.name
 

--- a/torch_em/transform/augmentation.py
+++ b/torch_em/transform/augmentation.py
@@ -121,7 +121,7 @@ class KorniaAugmentationPipeline(torch.nn.Module):
 # Try out:
 # - RandomPerspective
 AUGMENTATIONS = {
-    "RandomAffine": {"degrees": 90,"scale": (0.9, 1.1)},
+    "RandomAffine": {"degrees": 90, "scale": (0.9, 1.1)},
     "RandomAffine3D": {"degrees": (90, 90, 90), "scale": (0.0, 1.1)},
     "RandomDepthicalFlip3D": {},
     "RandomHorizontalFlip": {},


### PR DESCRIPTION
Improve offline wandb run name (no colon). Now the resulting file path is also valid on windows.

hitchhiking on this PR: `import torch.utils.data` for `torch.utils.data.DataLoader`  (previously it was only `import torch`)