### PR TITLE
Updated SegmentationDataset to support 4D images

### DIFF
--- a/torch_em/data/segmentation_dataset.py
+++ b/torch_em/data/segmentation_dataset.py
@@ -55,8 +55,9 @@ class SegmentationDataset(torch.utils.data.Dataset):
             self.raw = RoiWrapper(self.raw, roi)
             self.labels = RoiWrapper(self.labels, roi)
         self.roi = roi
-
-        assert len(patch_shape) == self.raw.ndim
+        
+        # it supports nD patches that results in a 3D or 2D images when squeezed
+        assert len(patch_shape) >= self.raw.ndim
         self.patch_shape = patch_shape
 
         self.raw_transform = raw_transform


### PR DESCRIPTION
This PR is related to constantinpape/elf#36

I think using greater or equal could be a compromise. It allows using higher-dimensional datasets, when performing the slicing it will still have the desirable property of crashing when indexing a lower-dimensional dataset with a slice of greater dimensions, and the assertion catches when using a `patch_shape` smaller than the `raw.ndim`, which could lead to silent undesirable behavior.

Let me know if you have any suggestions, cheers.