### PR TITLE
Support training with channels

### DIFF
--- a/test/data/test_segmentation_dataset.py
+++ b/test/data/test_segmentation_dataset.py
@@ -1,18 +1,27 @@
 import os
 import unittest
+
+import h5py
 import numpy as np
 from torch_em.util.test import create_segmentation_test_data
 
 
 class TestSegmentationDataset(unittest.TestCase):
-    path = './data.h5'
-    raw_key = 'raw'
-    label_key = 'labels'
+    path = "./data.h5"
+    raw_key = "raw"
+    channel_key = "raw_with_channels"
+    label_key = "labels"
     shape = (128,) * 3
 
     def setUp(self):
+        chunks = (32,) * 3
         create_segmentation_test_data(self.path, self.raw_key, self.label_key,
-                                      shape=self.shape, chunks=(32,) * 3)
+                                      shape=self.shape, chunks=chunks)
+        with h5py.File(self.path, "a") as f:
+            shape = (3,) + self.shape
+            chunks = (1,) + chunks
+            data_with_channels = np.random.rand(*shape)
+            f.create_dataset(self.channel_key, data=data_with_channels, chunks=chunks)
 
     def tearDown(self):
         os.remove(self.path)
@@ -52,6 +61,20 @@ class TestSegmentationDataset(unittest.TestCase):
             self.assertEqual(x.shape, expected_shape)
             self.assertEqual(y.shape, expected_shape)
 
+    def test_with_channels(self):
+        from torch_em.data import SegmentationDataset
+        patch_shape = (32, 32, 32)
+        ds = SegmentationDataset(self.path, self.channel_key,
+                                 self.path, self.label_key,
+                                 patch_shape=patch_shape, ndim=3)
+        self.assertEqual(ds._ndim, 3)
+        expected_raw_shape = (3,) + patch_shape
+        expected_label_shape = (1,) + patch_shape
+        for i in range(10):
+            x, y = ds[i]
+            self.assertEqual(x.shape, expected_raw_shape)
+            self.assertEqual(y.shape, expected_label_shape)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/test/data/test_segmentation_dataset.py
+++ b/test/data/test_segmentation_dataset.py
@@ -42,6 +42,23 @@ class TestSegmentationDataset(unittest.TestCase):
             self.assertEqual(x.shape, expected_shape)
             self.assertEqual(y.shape, expected_shape)
 
+    def test_dataset_2d(self):
+        from torch_em.data import SegmentationDataset
+        patch_shape = (1, 32, 32)
+        ds = SegmentationDataset(self.path, self.raw_key,
+                                 self.path, self.label_key,
+                                 patch_shape=patch_shape,
+                                 ndim=2)
+        self.assertEqual(ds.raw.shape, self.shape)
+        self.assertEqual(ds.labels.shape, self.shape)
+        self.assertEqual(ds._ndim, 2)
+
+        expected_shape = patch_shape
+        for i in range(10):
+            x, y = ds[i]
+            self.assertEqual(x.shape, expected_shape)
+            self.assertEqual(y.shape, expected_shape)
+
     def test_roi(self):
         from torch_em.data import SegmentationDataset
         patch_shape = (32, 32, 32)
@@ -66,7 +83,8 @@ class TestSegmentationDataset(unittest.TestCase):
         patch_shape = (32, 32, 32)
         ds = SegmentationDataset(self.path, self.channel_key,
                                  self.path, self.label_key,
-                                 patch_shape=patch_shape, ndim=3)
+                                 patch_shape=patch_shape, ndim=3,
+                                 with_channels=True)
         self.assertEqual(ds._ndim, 3)
         expected_raw_shape = (3,) + patch_shape
         expected_label_shape = (1,) + patch_shape

--- a/torch_em/data/segmentation_dataset.py
+++ b/torch_em/data/segmentation_dataset.py
@@ -13,7 +13,7 @@ class SegmentationDataset(torch.utils.data.Dataset):
 
     @staticmethod
     def compute_len(path, key, patch_shape):
-        with open_file(path, mode='r') as f:
+        with open_file(path, mode="r") as f:
             shape = f[key].shape
         n_samples = int(np.prod(
             [float(sh / csh) for sh, csh in zip(shape, patch_shape)]
@@ -40,23 +40,39 @@ class SegmentationDataset(torch.utils.data.Dataset):
     ):
         self.raw_path = raw_path
         self.raw_key = raw_key
-        self.raw = open_file(raw_path, mode='r')[raw_key]
+        self.raw = open_file(raw_path, mode="r")[raw_key]
 
         self.label_path = label_path
         self.label_key = label_key
-        self.labels = open_file(label_path, mode='r')[label_key]
+        self.labels = open_file(label_path, mode="r")[label_key]
 
-        assert self.raw.shape == self.labels.shape
-        self._ndim = self.raw.ndim if ndim is None else ndim
-        assert self._ndim in (2, 3)
+        if ndim is None:
+            assert self.raw.shape == self.labels.shape, f"{self.raw.shape}, {self.labels.shape}"
+            self._ndim = self.raw.ndim
+            self._with_channels = False
+        else:
+            self._ndim = ndim
+            # check if the raw data has channels
+            if self.raw.ndim == ndim + 1:
+                assert self.raw.shape[1:] == self.labels.shape, f"{self.raw.shape[1:]}, {self.labels.shape}"
+                self._with_channels = True
+            elif self.raw.ndim == ndim:
+                assert self.raw.shape == self.labels.shape, f"{self.raw.shape}, {self.labels.shape}"
+                self._with_channels = False
+            else:
+                raise ValueError(f"Invalid raw data dimensionality {self.raw.ndim} for ndim={ndim}.")
+
+        assert self._ndim in (2, 3), "Invalid data dimensionality: {self._ndim}. Only 2d or 3d data is supported"
 
         if roi is not None:
-            assert len(roi) == self.raw.ndim
-            self.raw = RoiWrapper(self.raw, roi)
+            assert len(roi) == self._ndim
+            self.raw = RoiWrapper(self.raw, (slice(None),) + roi) if self._with_channels else RoiWrapper(self.raw, roi)
             self.labels = RoiWrapper(self.labels, roi)
+
+        self.shape = self.labels.shape
         self.roi = roi
 
-        assert len(patch_shape) == self.raw.ndim
+        assert len(patch_shape) == self._ndim
         self.patch_shape = patch_shape
 
         self.raw_transform = raw_transform
@@ -68,8 +84,7 @@ class SegmentationDataset(torch.utils.data.Dataset):
         self.dtype = dtype
         self.label_dtype = label_dtype
 
-        self._len = self.compute_len(raw_path, raw_key, self.patch_shape) if n_samples is None\
-            else n_samples
+        self._len = self.compute_len(label_path, label_key, self.patch_shape) if n_samples is None else n_samples
 
         # TODO
         self.trafo_halo = None
@@ -94,19 +109,25 @@ class SegmentationDataset(torch.utils.data.Dataset):
     def _sample_bounding_box(self):
         bb_start = [
             np.random.randint(0, sh - psh) if sh - psh > 0 else 0
-            for sh, psh in zip(self.raw.shape, self.sample_shape)
+            for sh, psh in zip(self.shape, self.sample_shape)
         ]
         return tuple(slice(start, start + psh) for start, psh in zip(bb_start, self.sample_shape))
 
     def _get_sample(self, index):
         bb = self._sample_bounding_box()
-        raw, labels = self.raw[bb], self.labels[bb]
+        if self._with_channels:
+            raw, labels = self.raw[(slice(None),) + bb], self.labels[bb]
+        else:
+            raw, labels = self.raw[bb], self.labels[bb]
 
         if self.sampler is not None:
             sample_id = 0
             while not self.sampler(raw, labels):
                 bb = self._sample_bounding_box()
-                raw, labels = self.raw[bb], self.labels[bb]
+                if self._with_channels:
+                    raw, labels = self.raw[(slice(None),) + bb], self.labels[bb]
+                else:
+                    raw, labels = self.raw[bb], self.labels[bb]
                 sample_id += 1
                 if sample_id > self.max_sampling_attempts:
                     raise RuntimeError(f"Could not sample a valid batch in {self.max_sampling_attempts} attempts")
@@ -147,11 +168,11 @@ class SegmentationDataset(torch.utils.data.Dataset):
     # need to overwrite pickle to support h5py
     def __getstate__(self):
         state = self.__dict__.copy()
-        del state['raw']
-        del state['labels']
+        del state["raw"]
+        del state["labels"]
         return state
 
     def __setstate__(self, state):
-        state['raw'] = open_file(state['raw_path'], mode='r')[state['raw_key']]
-        state['labels'] = open_file(state['label_path'], mode='r')[state['label_key']]
+        state["raw"] = open_file(state["raw_path"], mode="r")[state["raw_key"]]
+        state["labels"] = open_file(state["label_path"], mode="r")[state["label_key"]]
         self.__dict__.update(state)

--- a/torch_em/segmentation.py
+++ b/torch_em/segmentation.py
@@ -161,8 +161,8 @@ def _load_image_collection_dataset(raw_paths, raw_key, label_paths, label_key, r
     return ds
 
 
-def _get_default_transform(path, key, is_seg_dataset):
-    if is_seg_dataset:
+def _get_default_transform(path, key, is_seg_dataset, ndim):
+    if is_seg_dataset and ndim is None:
         with open_file(path, mode="r") as f:
             shape = f[key].shape
             if len(shape) == 2:
@@ -171,6 +171,8 @@ def _get_default_transform(path, key, is_seg_dataset):
                 # heuristics to figure out whether to use default 3d
                 # or default anisotropic augmentations
                 ndim = "anisotropic" if shape[0] < shape[1] // 2 else 3
+    elif is_seg_dataset and ndim is not None:
+        pass
     else:
         ndim = 2
     return get_augmentations(ndim)
@@ -246,7 +248,7 @@ def default_segmentation_dataset(
     # we always use augmentations in the convenience function
     if transform is None:
         transform = _get_default_transform(
-            raw_paths if isinstance(raw_paths, str) else raw_paths[0], raw_key, is_seg_dataset
+            raw_paths if isinstance(raw_paths, str) else raw_paths[0], raw_key, is_seg_dataset, ndim
         )
 
     if is_seg_dataset:

--- a/torch_em/segmentation.py
+++ b/torch_em/segmentation.py
@@ -196,6 +196,7 @@ def default_segmentation_loader(
     sampler=None,
     ndim=None,
     is_seg_dataset=None,
+    with_channels=False,
     **loader_kwargs,
 ):
     ds = default_segmentation_dataset(
@@ -215,6 +216,7 @@ def default_segmentation_loader(
         sampler=sampler,
         ndim=ndim,
         is_seg_dataset=is_seg_dataset,
+        with_channels=with_channels,
     )
     return get_data_loader(ds, batch_size=batch_size, **loader_kwargs)
 
@@ -236,6 +238,7 @@ def default_segmentation_dataset(
     sampler=None,
     ndim=None,
     is_seg_dataset=None,
+    with_channels=False,
 ):
     check_paths(raw_paths, label_paths)
     if is_seg_dataset is None:
@@ -268,8 +271,10 @@ def default_segmentation_dataset(
             ndim=ndim,
             dtype=dtype,
             label_dtype=label_dtype,
+            with_channels=with_channels,
         )
     else:
+        # TODO implement with channels for image collection
         ds = _load_image_collection_dataset(
             raw_paths,
             raw_key,

--- a/torch_em/util/test.py
+++ b/torch_em/util/test.py
@@ -5,20 +5,20 @@ import numpy as np
 
 
 def create_segmentation_test_data(data_path, raw_key, label_key, shape, chunks):
-    with h5py.File(data_path, 'a') as f:
+    with h5py.File(data_path, "a") as f:
         f.create_dataset(raw_key, data=np.random.rand(*shape), chunks=chunks)
         f.create_dataset(label_key, data=np.random.randint(0, 4, size=shape), chunks=chunks)
 
 
 def create_image_collection_test_data(folder, n_images, min_shape, max_shape):
-    im_folder = os.path.join(folder, 'images')
-    label_folder = os.path.join(folder, 'labels')
+    im_folder = os.path.join(folder, "images")
+    label_folder = os.path.join(folder, "labels")
     os.makedirs(im_folder, exist_ok=True)
     os.makedirs(label_folder, exist_ok=True)
 
     for i in range(n_images):
         shape = tuple(np.random.randint(mins, maxs) for mins, maxs in zip(min_shape, max_shape))
-        raw = np.random.rand(*shape).astype('int16')
+        raw = np.random.rand(*shape).astype("int16")
         label = np.random.randint(0, 4, size=shape)
         imageio.imwrite(os.path.join(im_folder, f"im_{i}.tif"), raw)
         imageio.imwrite(os.path.join(label_folder, f"im_{i}.tif"), label)


### PR DESCRIPTION
This PR implements training with channels in the raw data. This only works for data with channel first (torch-native) and if `ndim=2/3, with_channels=True` is passed explicitly to `torch_em.default_segmentation_loader` / `torch_em.default_segmentation_dataset`.
~~The changes are fairly small, but I am not sure if this invalidates old checkpoints (because the `SegmentationDataset` is pickled within them); will check later before merging this.~~

Edit: checked, checkpoints can still be loaded

cc @FynnBe 