### PR TITLE
fix bugs for pseudo-label learning

### DIFF
--- a/torch_em/shallow2deep/shallow2deep_model.py
+++ b/torch_em/shallow2deep/shallow2deep_model.py
@@ -88,7 +88,7 @@ class Shallow2DeepModel:
         return model
 
     @staticmethod
-    def load_rf(rf_config, rf_channel, ilastik_multi_thread):
+    def load_rf(rf_config, rf_channel=1, ilastik_multi_thread=False):
         if len(rf_config) == 3:  # random forest path and feature config
             rf_path, ndim, filter_config = rf_config
             assert os.path.exists(rf_path)


### PR DESCRIPTION
adapt order of transform to work for pseudo-label training (rf_predictor takes raw (not-normalized) input).
add default values to load_rf since otherwise torch.load in trainer throws error when trying to load from checkpoint.