### PR TITLE
fix _crop() behavior if diff is 1

### DIFF
--- a/torch_em/model/unet.py
+++ b/torch_em/model/unet.py
@@ -1,3 +1,5 @@
+from math import ceil, floor
+
 import torch
 import torch.nn as nn
 
@@ -310,8 +312,9 @@ class Decoder(nn.Module):
     # FIXME this prevents traces from being valid for other input sizes, need to find
     # a solution to traceable cropping
     def _crop(self, x, shape):
-        shape_diff = [(xsh - sh) // 2 for xsh, sh in zip(x.shape, shape)]
-        crop = tuple([slice(sd, xsh - sd) for sd, xsh in zip(shape_diff, x.shape)])
+        lower = [ceil((xsh - sh) / 2) for xsh, sh in zip(x.shape, shape)]
+        upper = [floor((xsh - sh) / 2) for xsh, sh in zip(x.shape, shape)]
+        crop = tuple([slice(l, xsh - u) for l, u, xsh in zip(lower, upper, x.shape)])
         return x[crop]
         # # Implementation with torch.narrow, does not fix the tracing warnings!
         # for dim, (sh, sd) in enumerate(zip(shape, shape_diff)):


### PR DESCRIPTION
I had the case that the shape of x is [1, 1, 625, 625] and shape is [1, 1, 624, 624], so the shape diff is 1. In this case _crop() does not crop, which leads to an error in the calling function. I am not sure if this is a case that should not occur but here I provide a potential fix.

Some sample code decribing the problem:

```
from math import ceil, floor
import torch

def _crop(x, shape):
    shape_diff = [(xsh - sh) // 2 for xsh, sh in zip(x.shape, shape)]
    crop = tuple([slice(sd, xsh - sd) for sd, xsh in zip(shape_diff, x.shape)])
    return x[crop]

def _crop_new(x, shape):
    lower = [ceil((xsh - sh) / 2) for xsh, sh in zip(x.shape, shape)]
    upper = [floor((xsh - sh) / 2) for xsh, sh in zip(x.shape, shape)]
    crop = tuple([slice(l, xsh - u) for l, u, xsh in zip(lower, upper, x.shape)])
    return x[crop]

x = torch.rand(1, 1, 5, 5)
shape = [1, 1, 4, 4]

print(_crop(x, shape).shape) # no crop happening
print(_crop_new(x, shape).shape)

print(_crop(x, shape))
print(_crop_new(x, shape))
```
