### PR TITLE
Allow logger to generate a (run) id

### DIFF
--- a/torch_em/segmentation.py
+++ b/torch_em/segmentation.py
@@ -315,6 +315,7 @@ def default_segmentation_trainer(
     scheduler_kwargs=DEFAULT_SCHEDULER_KWARGS,
     optimizer_kwargs={},
     trainer_class=DefaultTrainer,
+    id_=None,
 ):
     optimizer = torch.optim.Adam(model.parameters(), lr=learning_rate, **optimizer_kwargs)
     scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, **scheduler_kwargs)

--- a/torch_em/segmentation.py
+++ b/torch_em/segmentation.py
@@ -346,6 +346,7 @@ def default_segmentation_trainer(
         early_stopping=early_stopping,
         log_image_interval=log_image_interval,
         logger=logger,
-        logger_kwargs=logger_kwargs
+        logger_kwargs=logger_kwargs,
+        id_=id_,
     )
     return trainer

--- a/torch_em/trainer/default_trainer.py
+++ b/torch_em/trainer/default_trainer.py
@@ -33,13 +33,14 @@ class DefaultTrainer:
         early_stopping=None,
         logger=TensorboardLogger,
         logger_kwargs: Optional[Dict[str, Any]] = None,
+        id_: Optional[str] = None,
     ):
         if name is None and not issubclass(logger, WandbLogger):
             raise TypeError("Name cannot be None if not using the WandbLogger")
 
         self._generate_name = name is None
         self.name = name
-        self.id = name
+        self.id_ = id_ or name
         self.train_loader = train_loader
         self.val_loader = val_loader
         self.model = model
@@ -65,8 +66,8 @@ class DefaultTrainer:
 
     @property  # because the logger may generate and set trainer.id on logger.__init__
     def checkpoint_folder(self):
-        assert self.id is not None
-        return os.path.join("./checkpoints", self.id)
+        assert self.id_ is not None
+        return os.path.join("./checkpoints", self.id_)
 
     @property
     def iteration(self):

--- a/torch_em/trainer/default_trainer.py
+++ b/torch_em/trainer/default_trainer.py
@@ -39,6 +39,7 @@ class DefaultTrainer:
 
         self._generate_name = name is None
         self.name = name
+        self.id = name
         self.train_loader = train_loader
         self.val_loader = val_loader
         self.model = model
@@ -62,10 +63,10 @@ class DefaultTrainer:
         self.logger_kwargs = logger_kwargs
         self.log_image_interval = log_image_interval
 
-    @property  # because the logger may generate and set trainer.name on logger.__init__
+    @property  # because the logger may generate and set trainer.id on logger.__init__
     def checkpoint_folder(self):
-        assert self.name is not None
-        return os.path.join("./checkpoints", self.name)
+        assert self.id is not None
+        return os.path.join("./checkpoints", self.id)
 
     @property
     def iteration(self):

--- a/torch_em/trainer/wandb_logger.py
+++ b/torch_em/trainer/wandb_logger.py
@@ -29,6 +29,7 @@ class WandbLogger(TorchEmLogger):
         log_model_graph: bool = True,
         mode: Literal["online", "offline", "disabled"] = "online",
         config: Optional[dict] = None,
+        resume: Optional[str] = None,
         **unused_kwargs,
     ):
         if wandb is None:
@@ -42,14 +43,16 @@ class WandbLogger(TorchEmLogger):
         config = dict(config or {})
         config.update(trainer.init_data)
         self.wand_run = wandb.init(
-            project=project_name, name=trainer.name, dir=self.log_dir, mode=mode, config=config
+            id=resume, project=project_name, name=trainer.name, dir=self.log_dir, mode=mode, config=config, resume="allow"
         )
+        trainer.id = self.wand_run.id
 
         if trainer.name is None:
             if mode == "online":
                 trainer.name = self.wand_run.name
             elif mode in ("offline", "disabled"):
                 trainer.name = f"{mode}_{datetime.now():%Y-%m-%d_%H-%M-%S}"
+                trainer.id = trainer.name  # if we don't upload the log, name with time stamp is a better run id
             else:
                 raise ValueError(mode)
 


### PR DESCRIPTION
- optional `id_` argument for trainer (fallback to `name`)
- the logger might set `id_` if not given (if `id_`  is None)

allows to let the logger (e.g. `WandbLogger`) to set a run id to save checkpoints of independent runs in their respective folders, etc...