### PR TITLE
fix best_metric < worst_metric

### DIFF
--- a/torch_em/trainer/wandb_logger.py
+++ b/torch_em/trainer/wandb_logger.py
@@ -89,7 +89,7 @@ class WandbLogger(TorchEmLogger):
         if loss < self.wand_run.summary.get("validation/loss", np.inf):
             self.wand_run.summary["validation/loss"] = loss
 
-        if metric > self.wand_run.summary.get("validation/metric", np.inf):
+        if metric < self.wand_run.summary.get("validation/metric", np.inf):
             self.wand_run.summary["validation/metric"] = metric
 
         self._log_images(step, x, y, prediction, "validation")


### PR DESCRIPTION
If I understand correctly torch-em considers metric values to be ordered as loss values (smaller is better)... 
If so, then this PR fixes a bug for logging the best metric so the wandb summary.
