### PR TITLE
Fix deserialization by applying RoiWrapper

### DIFF
--- a/torch_em/data/segmentation_dataset.py
+++ b/torch_em/data/segmentation_dataset.py
@@ -18,6 +18,14 @@ class SegmentationDataset(torch.utils.data.Dataset):
         n_samples = int(np.prod([float(sh / csh) for sh, csh in zip(shape, patch_shape)]))
         return n_samples
 
+    @staticmethod
+    def apply_roi(data, roi, with_channels):
+        if roi is not None:
+            if isinstance(roi, slice):
+                roi = (roi,)
+            return RoiWrapper(data, (slice(None),) + roi) if with_channels else RoiWrapper(data, roi)
+        return data
+
     def __init__(
         self,
         raw_path,
@@ -49,12 +57,8 @@ class SegmentationDataset(torch.utils.data.Dataset):
         self._with_channels = with_channels
         self._with_label_channels = with_label_channels
 
-        if roi is not None:
-            if isinstance(roi, slice):
-                roi = (roi,)
-            self.raw = RoiWrapper(self.raw, (slice(None),) + roi) if self._with_channels else RoiWrapper(self.raw, roi)
-            self.labels = RoiWrapper(self.labels, (slice(None),) + roi) if self._with_label_channels else\
-                RoiWrapper(self.labels, roi)
+        self.raw = self.apply_roi(self.raw, roi, self._with_channels)
+        self.labels = self.apply_roi(self.labels, roi, self._with_label_channels)
 
         shape_raw = self.raw.shape[1:] if self._with_channels else self.raw.shape
         shape_label = self.labels.shape[1:] if self._with_label_channels else self.labels.shape
@@ -173,8 +177,11 @@ class SegmentationDataset(torch.utils.data.Dataset):
     def __setstate__(self, state):
         raw_path, raw_key = state["raw_path"], state["raw_key"]
         label_path, label_key = state["label_path"], state["label_key"]
-        try:
-            state["raw"] = open_file(raw_path, mode="r")[raw_key]
+        try: # can still use model even if data is not available anymore
+            raw = open_file(state["raw_path"], mode="r")[state["raw_key"]]
+            roi = state["roi"]
+            with_channels = state["_with_channels"]
+            state["raw"] = self.apply_roi(raw, roi, with_channels)
         except Exception:
             msg = f"SegmentationDataset could not be deserialized because of missing {raw_path}, {raw_key}.\n"
             msg += "The dataset is deserialized in order to allow loading trained models from a checkpoint.\n"
@@ -182,7 +189,10 @@ class SegmentationDataset(torch.utils.data.Dataset):
             warnings.warn(msg)
             state["raw"] = None
         try:
-            state["labels"] = open_file(label_path, mode="r")[label_key]
+            labels = open_file(state["label_path"], mode="r")[state["label_key"]]
+            roi = state["roi"]
+            with_channels = state["_with_channels"]
+            state["labels"] = self.apply_roi(labels, roi, with_channels)
         except Exception:
             msg = f"SegmentationDataset could not be deserialized because of missing {label_path}, {label_key}.\n"
             msg += "The dataset is deserialized in order to allow loading trained models from a checkpoint.\n"

--- a/torch_em/model/unet.py
+++ b/torch_em/model/unet.py
@@ -322,9 +322,8 @@ class Decoder(nn.Module):
     # FIXME this prevents traces from being valid for other input sizes, need to find
     # a solution to traceable cropping
     def _crop(self, x, shape):
-        lower = [ceil((xsh - sh) / 2) for xsh, sh in zip(x.shape, shape)]
-        upper = [floor((xsh - sh) / 2) for xsh, sh in zip(x.shape, shape)]
-        crop = tuple([slice(l, xsh - u) for l, u, xsh in zip(lower, upper, x.shape)])
+        shape_diff = [(xsh - sh) // 2 for xsh, sh in zip(x.shape, shape)]
+        crop = tuple([slice(sd, xsh - sd) for sd, xsh in zip(shape_diff, x.shape)])
         return x[crop]
         # # Implementation with torch.narrow, does not fix the tracing warnings!
         # for dim, (sh, sd) in enumerate(zip(shape, shape_diff)):

--- a/torch_em/model/unet.py
+++ b/torch_em/model/unet.py
@@ -322,8 +322,9 @@ class Decoder(nn.Module):
     # FIXME this prevents traces from being valid for other input sizes, need to find
     # a solution to traceable cropping
     def _crop(self, x, shape):
-        shape_diff = [(xsh - sh) // 2 for xsh, sh in zip(x.shape, shape)]
-        crop = tuple([slice(sd, xsh - sd) for sd, xsh in zip(shape_diff, x.shape)])
+        lower = [ceil((xsh - sh) / 2) for xsh, sh in zip(x.shape, shape)]
+        upper = [floor((xsh - sh) / 2) for xsh, sh in zip(x.shape, shape)]
+        crop = tuple([slice(l, xsh - u) for l, u, xsh in zip(lower, upper, x.shape)])
         return x[crop]
         # # Implementation with torch.narrow, does not fix the tracing warnings!
         # for dim, (sh, sd) in enumerate(zip(shape, shape_diff)):


### PR DESCRIPTION
Should fix the issue by applying the RoiWrapper while unpickling.
Sample Code:

```
import numpy as np
import pickle
from torch_em.data import RawDataset, SegmentationDataset

path = '/g/kreshuk/hellgoth/domain_adaptation/data/cremi/sample_A_20160501_copy.hdf5'
raw_key = 'volumes/raw' # (125, 1250, 1250)
label_key = 'volumes/labels/neuron_ids' # (125, 1250, 1250)

# RawDataset
ds_raw = RawDataset(
    raw_path=path,
    raw_key=raw_key,
    patch_shape=(32, 256, 256),
    roi=np.s_[:50, :1000, :1000]
)

print(ds_raw)
print(ds_raw.raw.shape) # (50, 1000, 1000)

with open('test_file', 'wb') as f:
    pickle.dump(ds_raw, f)

with open('test_file', 'rb') as f:
    ds_loaded_raw = pickle.load(f)

print(ds_loaded_raw)
print(ds_loaded_raw.raw.shape) # old behavior: (125, 1250, 1250), new behavior: (50, 1000, 1000)


# SegmentationDataset
ds_seg = SegmentationDataset(
    raw_path=path,
    raw_key=raw_key,
    label_path=path,
    label_key=label_key,
    patch_shape=(32, 256, 256),
    roi=np.s_[:50, :1000, :1000]
)

print(ds_seg)
print(ds_seg.raw.shape) # (50, 1000, 1000)
print(ds_seg.labels.shape) # (50, 1000, 1000)

with open('test_file2', 'wb') as f:
    pickle.dump(ds_seg, f)

with open('test_file2', 'rb') as f:
    ds_loaded_seg = pickle.load(f)

print(ds_loaded_seg)
print(ds_loaded_seg.raw.shape) # old behavior: (125, 1250, 1250), new behavior: (50, 1000, 1000)
print(ds_loaded_seg.labels.shape) # old behavior: (125, 1250, 1250), new behavior: (50, 1000, 1000)
```