### PR TITLE
Add functionality to mask to-bg-boundaries

### DIFF
--- a/torch_em/data/__init__.py
+++ b/torch_em/data/__init__.py
@@ -5,4 +5,10 @@ from .raw_dataset import RawDataset
 from .pseudo_label_dataset import PseudoLabelDataset
 from .raw_image_collection_dataset import RawImageCollectionDataset
 from .segmentation_dataset import SegmentationDataset
-from .sampler import MinForegroundSampler, MinIntensitySampler
+from .sampler import (
+    MinForegroundSampler,
+    MinInstanceSampler,
+    MinIntensitySampler,
+    MinNoToBackgroundBoundarySampler,
+    MinTwoInstanceSampler,
+)

--- a/torch_em/loss/__init__.py
+++ b/torch_em/loss/__init__.py
@@ -3,7 +3,7 @@ from .combined_loss import CombinedLoss
 from .contrastive import ContrastiveLoss
 from .dice import DiceLoss, dice_score
 from .spoco_loss import SPOCOLoss
-from .wrapper import ApplyAndRemoveMask, LossWrapper
+from .wrapper import ApplyAndRemoveMask, ApplyMask, LossWrapper, MaskIgnoreLabel
 
 EMBEDDING_LOSSES = (
     ContrastiveLoss, SPOCOLoss

--- a/torch_em/transform/__init__.py
+++ b/torch_em/transform/__init__.py
@@ -1,5 +1,5 @@
 from .augmentation import get_augmentations
 from .defect import EMDefectAugmentation, get_artifact_source
 from .generic import Tile
-from .label import AffinityTransform, BoundaryTransform, label_consecutive, labels_to_binary
+from .label import AffinityTransform, BoundaryTransform, NoToBackgroundBoundaryTransform, label_consecutive, labels_to_binary
 from .raw import get_raw_transform


### PR DESCRIPTION
The new BoundaryTransform labels the to-bg-boundaries with a dedicated label (e.g. -1).
This can already be interpreted by the RF training procedure.
MaskIgnoreLabel in combination with LossWrapper now also allows trainer instances to interpret this correctly.
The LossWrapper was modified to also allow a mask to be given directly (used via ApplyMask).
The new sampler is needed to make sure that there is still foreground signal left in the image after masking the to-bg-boundaries. Unfortunately, right now it calls the new BoundaryTransform.