### PR TITLE
Implement advanced rf training for s2d

### DIFF
--- a/experiments/shallow2deep/em-boundaries/train_isbi_2d.py
+++ b/experiments/shallow2deep/em-boundaries/train_isbi_2d.py
@@ -15,14 +15,25 @@ def prepare_shallow2deep_isbi(args, out_folder):
     raw_transform = torch_em.transform.raw.normalize
     label_transform = shallow2deep.BoundaryTransform(ndim=2)
 
-    shallow2deep.prepare_shallow2deep(
-        raw_paths=args.input, raw_key="volumes/raw",
-        label_paths=args.input, label_key="volumes/labels/neuron_ids_3d",
-        patch_shape_min=patch_shape_min, patch_shape_max=patch_shape_max,
-        n_forests=args.n_rfs, n_threads=args.n_threads,
-        output_folder=out_folder, ndim=2,
-        raw_transform=raw_transform, label_transform=label_transform,
-    )
+    if args.train_advanced:
+        shallow2deep.prepare_shallow2deep_advanced(
+            raw_paths=args.input, raw_key="volumes/raw",
+            label_paths=args.input, label_key="volumes/labels/neuron_ids_3d",
+            patch_shape_min=patch_shape_min, patch_shape_max=patch_shape_max,
+            n_forests=args.n_rfs, n_threads=args.n_threads,
+            output_folder=out_folder, ndim=2,
+            raw_transform=raw_transform, label_transform=label_transform,
+            forests_per_stage=25, sample_fraction_per_stage=0.1
+        )
+    else:
+        shallow2deep.prepare_shallow2deep(
+            raw_paths=args.input, raw_key="volumes/raw",
+            label_paths=args.input, label_key="volumes/labels/neuron_ids_3d",
+            patch_shape_min=patch_shape_min, patch_shape_max=patch_shape_max,
+            n_forests=args.n_rfs, n_threads=args.n_threads,
+            output_folder=out_folder, ndim=2,
+            raw_transform=raw_transform, label_transform=label_transform,
+        )
 
 
 def get_isbi_loader(args, split, rf_folder):
@@ -54,7 +65,7 @@ def get_isbi_loader(args, split, rf_folder):
 
 
 def train_shallow2deep(args):
-    name = "isbi2d"
+    name = "isbi2d-advanced" if args.train_advanced else "isbi2d"
 
     # check if we need to train the rfs for preparation
     rf_folder = os.path.join("checkpoints", name, "rfs")
@@ -133,6 +144,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--pseudo_label", type=int, default=0)
     parser.add_argument("--n_rfs", type=int, default=500)
     parser.add_argument("--n_threads", type=int, default=32)
+    parser.add_argument("--train_advanced", "-a", default=0)
     args = parser.parse_args()
     if args.check:
         check_loader(args)

--- a/experiments/shallow2deep/em-mitochondria/.gitignore
+++ b/experiments/shallow2deep/em-mitochondria/.gitignore
@@ -1,0 +1,1 @@
+bio-models/

--- a/experiments/shallow2deep/em-mitochondria/README.md
+++ b/experiments/shallow2deep/em-mitochondria/README.md
@@ -1,0 +1,24 @@
+# Shallow2Deep for mitochondria
+
+## Evaluation
+
+### V1
+
+Enhancers and direct model trained on VNC and applied to crops of MITO-EM; everything fully 2d.
+
+|                     |few-labels | many-labels|
+|---------------------|-----------|------------|
+|vanilla-enhancer     |0.263941   |   0.436766 |
+|advanced-enhancer    |0.319515   |   0.453895 |
+|rf-score             |0.163359   |   0.165454 |
+|direct-net           |0.178033   |   0.325530 |
+
+VNC model applied to the MITO-EM data: 0.035003
+
+### V2
+
+TODO: train on (MITO-EM) in 2d (to have bigger variety of shapes), use VNC for validation
+
+### V3
+
+TODO: train on mito-em in 3d (should work now, since fixing several bugs in training), find another 3d dataset for validation

--- a/experiments/shallow2deep/em-mitochondria/evaluation.py
+++ b/experiments/shallow2deep/em-mitochondria/evaluation.py
@@ -1,0 +1,114 @@
+import os
+from functools import partial
+
+import numpy as np
+
+from elf.io import open_file
+from elf.evaluation import matching, dice_score
+from skimage.measure import label
+from skimage.segmentation import watershed
+from torch_em.shallow2deep import evaluate_enhancers
+
+
+def cc_ws(pred):
+    fg, bd = pred[0], pred[1]
+    seeds = label(fg - bd > 0.5)
+    mask = fg + bd > 0.5
+    seg = watershed(bd, markers=seeds, mask=mask)
+    return seg
+
+
+# make cut-outs from mito-em for ilastik training and evaluation
+def prepare_eval_v1():
+    out_folder = "/g/kreshuk/pape/Work/data/mito_em/data/crops"
+    os.makedirs(out_folder, exist_ok=True)
+
+    train_bb = np.s_[:50, :1024, :1024]
+    test_bb = np.s_[50:, -1024:, -1024:]
+
+    input_path = "/scratch/pape/mito-em/human_val.n5"
+    with open_file(input_path, "r") as f:
+        dsr = f["raw"]
+        dsr.n_threads = 8
+        raw_train, raw_test = dsr[train_bb], dsr[test_bb]
+
+        dsl = f["labels"]
+        dsl.n_threads = 8
+        labels_train, labels_test = dsl[train_bb], dsl[test_bb]
+
+    with open_file(os.path.join(out_folder, "crop_train.h5"), "a") as f:
+        f.create_dataset("raw", data=raw_train, compression="gzip")
+        f.create_dataset("labels", data=labels_train, compression="gzip")
+
+    with open_file(os.path.join(out_folder, "crop_test.h5"), "a") as f:
+        f.create_dataset("raw", data=raw_test, compression="gzip")
+        f.create_dataset("labels", data=labels_test, compression="gzip")
+
+
+def _evaluation(data_path, rfs, enhancers, rf_channel, use_iou=False):
+    with open_file(data_path, "r") as f:
+        raw = f["raw"][:]
+        labels = f["labels"][:]
+    if use_iou:
+        metric = lambda x: matching(x)["precision"]
+        postprocess_rf = lambda x: label(x[0, 0] > 0.5)
+        postprocess_enhancer = cc_ws
+    else:
+        metric = partial(dice_score, threshold_seg=None)
+        postprocess_rf = lambda x: x[0, 0]
+        postprocess_enhancer = lambda x: x[0]
+
+    scores = evaluate_enhancers(raw, labels, enhancers, rfs, metric=metric,
+                                postprocess_rf=postprocess_rf,
+                                postprocess_enhancer=postprocess_enhancer,
+                                is2d=True, rf_channel=rf_channel)
+    return scores
+
+
+def _direct_evaluation(data_path, model_path):
+    import bioimageio.core
+    import xarray
+    from tqdm import trange
+
+    model = bioimageio.core.load_resource_description(model_path)
+    with open_file(data_path, "r") as f:
+        raw, labels = f["raw"][:], f["labels"][:]
+    scores = []
+
+    with bioimageio.core.create_prediction_pipeline(model) as pp:
+        for z in trange(raw.shape[0]):
+            inp = xarray.DataArray(raw[z][None, None], dims=tuple("bcyx"))
+            pred = pp(inp)[0].values[0, 0]
+            scores.append(dice_score(pred, labels[z], threshold_seg=None))
+
+    return np.mean(scores)
+
+
+def evaluation_v1():
+    data_root = "/g/kreshuk/pape/Work/data/mito_em/data/crops"
+    data_path = os.path.join(data_root, "crop_test.h5")
+    rfs = {
+        "few-labels": os.path.join(data_root, "rfs", "rf1.ilp"),
+        "many-labels": os.path.join(data_root, "rfs", "rf3.ilp"),
+    }
+    enhancers = {
+        "direct-net": "./bio-models/v1/DirectModel/mitchondriaemsegmentation2d_pytorch_state_dict.zip",
+    }
+    scores = _evaluation(data_path, rfs, enhancers, rf_channel=1)
+    enhancers = {
+        "direct-net": "./bio-models/v1/DirectModel/mitchondriaemsegmentation2d_pytorch_state_dict.zip",
+    }
+    scores_direct = _evaluation(data_path, rfs, enhancers, rf_channel=0)
+    scores = scores.append(scores_direct.iloc[0])
+
+    model_path = "./bio-models/v1/EnhancerMitochondriaEM2D/EnhancerMitochondriaEM2D.zip"
+    score_raw = _direct_evaluation(data_path, model_path)
+
+    print("Evaluation results:")
+    print(scores.to_markdown())
+    print("Raw net evaluation:", score_raw)
+
+
+if __name__ == "__main__":
+    # prepare_eval_v1()
+    evaluation_v1()

--- a/experiments/shallow2deep/em-mitochondria/export_enhancer.py
+++ b/experiments/shallow2deep/em-mitochondria/export_enhancer.py
@@ -1,0 +1,125 @@
+import argparse
+import os
+
+import h5py
+from torch_em.data.datasets import get_bioimageio_dataset_id
+from torch_em.util import (add_weight_formats,
+                           export_bioimageio_model,
+                           get_default_citations,
+                           get_training_summary)
+from torch_em.shallow2deep.shallow2deep_model import RFWithFilters, _get_filters
+
+
+def _get_name_and_description():
+    name = "EnhancerMitochondriaEM2D"
+    description = "Prediction enhancer for segmenting mitochondria in EM images."
+    return name, description
+
+
+def _get_doc(ckpt, name):
+    training_summary = get_training_summary(ckpt, to_md=True, lr=1.0e-4)
+    model_tag = name.lower()
+    doc = f"""#Prediction Enhancer for Mitochondrion Segmentation in EM
+
+This model was trained with the [Shallow2Deep](https://doi.org/10.3389/fcomp.2022.805166)
+method to improve ilastik predictions for mitochondria segmentation in EM.
+It predicts foreground and boundary probabilities.
+
+## Training
+
+The network was trained on data from [the VNC dataset](http://dx.doi.org/10.6084/m9.figshare.856713)
+and trained using [torch_em](https://github.com/constantinpape/torch-em).
+
+### Training Data
+
+- Imaging modality: Electron Microscopy
+- Dimensionality: 2D
+- Source: http://dx.doi.org/10.6084/m9.figshare.856713
+
+### Recommended Validation
+
+It is recommended to validate the instance segmentation obtained from this model using intersection-over-union.
+Note that this model expects foreground probabilities from a shallow classifer,
+such as a Random Forest, as input. It can thus be applied to new data of mitochondria, where only a
+new Random Forest for foreground and boundary segmentation needs to be trained, e.g. using ilastik.
+This model can be used in ilastik, deepimageJ or other software that supports the bioimage.io model format.
+
+### Training Schedule
+
+{training_summary}
+
+## Contact
+
+For questions or issues with this models, please reach out by:
+- opening a topic with tags bioimageio and {model_tag} on [image.sc](https://forum.image.sc/)
+- or creating an issue in https://github.com/constantinpape/torch-em"""
+    return doc
+
+
+def create_input(input_, checkpoint):
+    input_path = os.path.join(input_, "vnc_train.h5")
+    assert os.path.exists(input_path), input_path
+    with h5py.File(input_path, "r") as f:
+        data = f["raw"][-1, :512, :512]
+    rf_path = os.path.join(checkpoint, "rfs/rf_0.pkl")
+    assert os.path.exists(rf_path), rf_path
+    filter_config = _get_filters(2, None)
+    rf = RFWithFilters(rf_path, ndim=2, filter_config=filter_config, output_channel=1)
+    pred = rf(data)
+    return pred[None]
+
+
+def export_enhancer(input_, train_advanced):
+
+    if train_advanced:
+        checkpoint = "./checkpoints/shallow2deep-em-mitochondria-advanced"
+    else:
+        checkpoint = "./checkpoints/shallow2deep-em-mitochondria"
+    input_data = create_input(input_, checkpoint)
+
+    name, description = _get_name_and_description()
+    tags = ["unet", "mitochondria", "electron-microscopy", "instance-segmentation", "2d"]
+
+    # eventually we should refactor the citation logic
+    vnc_doi = "http://dx.doi.org/10.6084/m9.figshare.856713"
+    s2d_doi = "https://doi.org/10.3389/fcomp.2022.805166"
+    cite = get_default_citations(model="UNet2d", model_output="boundaries")
+    cite.append({"text": "data", "doi": vnc_doi})
+    cite.append({"text": "shallow2deep", "doi": s2d_doi})
+    doc = _get_doc(checkpoint, name)
+    additional_formats = ["torchscript"]
+
+    out_folder = "./bio-models"
+    os.makedirs(out_folder, exist_ok=True)
+    output = os.path.join(out_folder, name)
+
+    export_bioimageio_model(
+        checkpoint, output,
+        input_data=input_data,
+        name=name,
+        authors=[{"name": "Constantin Pape", "affiliation": "EMBL Heidelberg"}],
+        tags=tags,
+        license="CC-BY-4.0",
+        documentation=doc,
+        description=description,
+        git_repo="https://github.com/constantinpape/torch-em.git",
+        cite=cite,
+        input_optional_parameters=False,
+        # need custom deepimagej fields if we have torchscript export
+        for_deepimagej="torchscript" in additional_formats,
+        training_data={"id": get_bioimageio_dataset_id("vnc")},
+        maintainers=[{"github_user": "constantinpape"}],
+    )
+    add_weight_formats(output, additional_formats)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-i", "--input")
+    parser.add_argument("-a", "--train_advanced", default=0)
+    args = parser.parse_args()
+    export_enhancer(args.input)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/shallow2deep/em-mitochondria/train_vnc_2d.py
+++ b/experiments/shallow2deep/em-mitochondria/train_vnc_2d.py
@@ -1,0 +1,95 @@
+import os
+from glob import glob
+
+import numpy as np
+import torch_em
+import torch_em.shallow2deep as shallow2deep
+from torch_em.model import UNet2d
+from torch_em.data.datasets.vnc import _get_vnc_data
+
+
+def prepare_shallow2deep(args, out_folder):
+    patch_shape_min = [1, 512, 512]
+    patch_shape_max = [1, 768, 768]
+
+    raw_transform = torch_em.transform.raw.normalize
+    label_transform = shallow2deep.BoundaryTransform(ndim=2, add_binary_target=False)
+
+    path = os.path.join(args.input, "vnc_train.h5")
+    raw_key = "raw"
+    label_key = "labels/mitochondria"
+
+    if args.train_advanced:
+        shallow2deep.prepare_shallow2deep_advanced(
+            raw_paths=path, raw_key=raw_key, label_paths=path, label_key=label_key,
+            patch_shape_min=patch_shape_min, patch_shape_max=patch_shape_max,
+            n_forests=args.n_rfs, n_threads=args.n_threads,
+            forests_per_stage=25, sample_fraction_per_stage=0.1,
+            output_folder=out_folder, ndim=2,
+            raw_transform=raw_transform, label_transform=label_transform,
+            is_seg_dataset=True,
+        )
+    else:
+        shallow2deep.prepare_shallow2deep(
+            raw_paths=path, raw_key=raw_key, label_paths=path, label_key=label_key,
+            patch_shape_min=patch_shape_min, patch_shape_max=patch_shape_max,
+            n_forests=args.n_rfs, n_threads=args.n_threads,
+            output_folder=out_folder, ndim=2,
+            raw_transform=raw_transform, label_transform=label_transform,
+            is_seg_dataset=True,
+        )
+
+
+def get_loader(args, split, rf_folder):
+    rf_paths = glob(os.path.join(rf_folder, "*.pkl"))
+    rf_paths.sort()
+    patch_shape = (1, 512, 512)
+
+    path = os.path.join(args.input, "vnc_train.h5")
+    roi = np.s_[:18, :, :] if split == "train" else np.s_[18:, :, :]
+    n_samples = 500 if split == "train" else 25
+
+    raw_transform = torch_em.transform.raw.normalize
+    label_transform = torch_em.transform.BoundaryTransform(ndim=2, add_binary_target=True)
+    loader = shallow2deep.get_shallow2deep_loader(
+        raw_paths=path, raw_key="raw",
+        label_paths=path, label_key="labels/mitochondria",
+        rf_paths=rf_paths,
+        batch_size=args.batch_size, patch_shape=patch_shape,
+        raw_transform=raw_transform, label_transform=label_transform,
+        n_samples=n_samples, ndim=2, is_seg_dataset=True, shuffle=True,
+        num_workers=12, rois=roi
+    )
+    return loader
+
+
+def train_shallow2deep(args):
+    name = "shallow2deep-em-mitochondria" if args.train_advanced else "shallow2deep-em-mitochondria-advanced"
+    _get_vnc_data(args.input, download=True)
+
+    # check if we need to train the rfs for preparation
+    rf_folder = os.path.join("checkpoints", name, "rfs")
+    have_rfs = len(glob(os.path.join(rf_folder, "*.pkl"))) == args.n_rfs
+    if not have_rfs:
+        prepare_shallow2deep(args, rf_folder)
+    assert os.path.exists(rf_folder)
+
+    model = UNet2d(in_channels=1, out_channels=2, final_activation="Sigmoid",
+                   depth=4, initial_features=64)
+
+    train_loader = get_loader(args, "train", rf_folder)
+    val_loader = get_loader(args, "val", rf_folder)
+
+    trainer = torch_em.default_segmentation_trainer(
+        name, model, train_loader, val_loader, learning_rate=1.0e-4,
+        device=args.device, log_image_interval=50
+    )
+    trainer.fit(args.n_iterations)
+
+
+if __name__ == "__main__":
+    parser = torch_em.util.parser_helper()
+    parser.add_argument("--n_rfs", type=int, default=500)
+    parser.add_argument("--n_threads", type=int, default=32)
+    args = parser.parse_args()
+    train_shallow2deep(args)

--- a/experiments/shallow2deep/em-mitochondria/train_vnc_2d.py
+++ b/experiments/shallow2deep/em-mitochondria/train_vnc_2d.py
@@ -64,7 +64,7 @@ def get_loader(args, split, rf_folder):
 
 
 def train_shallow2deep(args):
-    name = "shallow2deep-em-mitochondria" if args.train_advanced else "shallow2deep-em-mitochondria-advanced"
+    name = "shallow2deep-em-mitochondria-advanced" if args.train_advanced else "shallow2deep-em-mitochondria"
     _get_vnc_data(args.input, download=True)
 
     # check if we need to train the rfs for preparation
@@ -89,6 +89,7 @@ def train_shallow2deep(args):
 
 if __name__ == "__main__":
     parser = torch_em.util.parser_helper()
+    parser.add_argument("--train_advanced", "-a", type=int, default=0)
     parser.add_argument("--n_rfs", type=int, default=500)
     parser.add_argument("--n_threads", type=int, default=32)
     args = parser.parse_args()

--- a/experiments/shallow2deep/em-mitochondria/train_vnc_2d.py
+++ b/experiments/shallow2deep/em-mitochondria/train_vnc_2d.py
@@ -9,11 +9,11 @@ from torch_em.data.datasets.vnc import _get_vnc_data
 
 
 def prepare_shallow2deep(args, out_folder):
-    patch_shape_min = [1, 512, 512]
-    patch_shape_max = [1, 768, 768]
+    patch_shape_min = [1, 256, 256]
+    patch_shape_max = [1, 512, 512]
 
     raw_transform = torch_em.transform.raw.normalize
-    label_transform = shallow2deep.BoundaryTransform(ndim=2, add_binary_target=False)
+    label_transform = shallow2deep.ForegroundTransform(ndim=2)
 
     path = os.path.join(args.input, "vnc_train.h5")
     raw_key = "raw"
@@ -24,7 +24,7 @@ def prepare_shallow2deep(args, out_folder):
             raw_paths=path, raw_key=raw_key, label_paths=path, label_key=label_key,
             patch_shape_min=patch_shape_min, patch_shape_max=patch_shape_max,
             n_forests=args.n_rfs, n_threads=args.n_threads,
-            forests_per_stage=25, sample_fraction_per_stage=0.1,
+            forests_per_stage=25, sample_fraction_per_stage=0.05,
             output_folder=out_folder, ndim=2,
             raw_transform=raw_transform, label_transform=label_transform,
             is_seg_dataset=True,
@@ -64,7 +64,9 @@ def get_loader(args, split, rf_folder):
 
 
 def train_shallow2deep(args):
-    name = "shallow2deep-em-mitochondria-advanced" if args.train_advanced else "shallow2deep-em-mitochondria"
+    name = "shallow2deep-em-mitochondria"
+    if args.train_advanced:
+        name += "-advanced"
     _get_vnc_data(args.input, download=True)
 
     # check if we need to train the rfs for preparation

--- a/experiments/shallow2deep/em-mitochondria/train_vnc_direct.py
+++ b/experiments/shallow2deep/em-mitochondria/train_vnc_direct.py
@@ -34,7 +34,5 @@ def train_direct(args):
 
 if __name__ == "__main__":
     parser = torch_em.util.parser_helper()
-    parser.add_argument("--n_rfs", type=int, default=500)
-    parser.add_argument("--n_threads", type=int, default=32)
     args = parser.parse_args()
     train_direct(args)

--- a/experiments/shallow2deep/em-mitochondria/train_vnc_direct.py
+++ b/experiments/shallow2deep/em-mitochondria/train_vnc_direct.py
@@ -1,0 +1,40 @@
+import numpy as np
+import torch_em
+from torch_em.model import UNet2d
+from torch_em.data.datasets import get_vnc_mito_loader
+
+
+def get_loader(args, split):
+    patch_shape = (1, 512, 512)
+
+    roi = np.s_[:18, :, :] if split == "train" else np.s_[18:, :, :]
+    n_samples = 500 if split == "train" else 25
+
+    loader = get_vnc_mito_loader(
+        args.input, boundaries=True,
+        batch_size=args.batch_size, patch_shape=patch_shape,
+        n_samples=n_samples, ndim=2, shuffle=True,
+        num_workers=12, rois=roi
+    )
+    return loader
+
+
+def train_direct(args):
+    name = "em-mitochondria"
+    model = UNet2d(in_channels=1, out_channels=2, final_activation="Sigmoid", depth=4, initial_features=64)
+
+    train_loader = get_loader(args, "train")
+    val_loader = get_loader(args, "val")
+
+    trainer = torch_em.default_segmentation_trainer(
+        name, model, train_loader, val_loader, learning_rate=1.0e-4, device=args.device, log_image_interval=50
+    )
+    trainer.fit(args.n_iterations)
+
+
+if __name__ == "__main__":
+    parser = torch_em.util.parser_helper()
+    parser.add_argument("--n_rfs", type=int, default=500)
+    parser.add_argument("--n_threads", type=int, default=32)
+    args = parser.parse_args()
+    train_direct(args)

--- a/experiments/shallow2deep/em-mitochondria/visualize_rfs.py
+++ b/experiments/shallow2deep/em-mitochondria/visualize_rfs.py
@@ -1,0 +1,22 @@
+import argparse
+import h5py
+from torch_em.shallow2deep import visualize_pretrained_rfs
+from torch_em.transform.raw import normalize
+
+
+def visualize_rfs():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-c", "--checkpoint", required=True)
+    args = parser.parse_args()
+    n_forests = 24
+
+    raw_path = "/scratch/pape/vnc/vnc_test.h5"
+    with h5py.File(raw_path, "r") as f:
+        raw = f["raw"][10]
+    raw = normalize(raw)
+
+    visualize_pretrained_rfs(args.checkpoint, raw, n_forests, n_threads=8)
+
+
+if __name__ == "__main__":
+    visualize_rfs()

--- a/torch_em/shallow2deep/__init__.py
+++ b/torch_em/shallow2deep/__init__.py
@@ -1,4 +1,4 @@
-from .prepare_shallow2deep import prepare_shallow2deep
+from .prepare_shallow2deep import prepare_shallow2deep, prepare_shallow2deep_advanced
 from .pseudolabel_training import get_pseudolabel_loader
 from .shallow2deep_dataset import get_shallow2deep_loader
 from .transform import BoundaryTransform, ForegroundTransform

--- a/torch_em/shallow2deep/__init__.py
+++ b/torch_em/shallow2deep/__init__.py
@@ -1,4 +1,6 @@
-from .prepare_shallow2deep import prepare_shallow2deep, prepare_shallow2deep_advanced
+from .prepare_shallow2deep import (prepare_shallow2deep,
+                                   prepare_shallow2deep_advanced,
+                                   visualize_pretrained_rfs)
 from .pseudolabel_training import get_pseudolabel_loader
 from .shallow2deep_dataset import get_shallow2deep_loader
 from .transform import BoundaryTransform, ForegroundTransform

--- a/torch_em/shallow2deep/__init__.py
+++ b/torch_em/shallow2deep/__init__.py
@@ -1,6 +1,5 @@
-from .prepare_shallow2deep import (prepare_shallow2deep,
-                                   prepare_shallow2deep_advanced,
-                                   visualize_pretrained_rfs)
+from .prepare_shallow2deep import prepare_shallow2deep, prepare_shallow2deep_advanced
 from .pseudolabel_training import get_pseudolabel_loader
 from .shallow2deep_dataset import get_shallow2deep_loader
+from .shallow2deep_eval import visualize_pretrained_rfs
 from .transform import BoundaryTransform, ForegroundTransform

--- a/torch_em/shallow2deep/__init__.py
+++ b/torch_em/shallow2deep/__init__.py
@@ -1,5 +1,5 @@
 from .prepare_shallow2deep import prepare_shallow2deep, prepare_shallow2deep_advanced
 from .pseudolabel_training import get_pseudolabel_loader
 from .shallow2deep_dataset import get_shallow2deep_loader
-from .shallow2deep_eval import visualize_pretrained_rfs
+from .shallow2deep_eval import visualize_pretrained_rfs, evaluate_enhancers
 from .transform import BoundaryTransform, ForegroundTransform

--- a/torch_em/shallow2deep/prepare_shallow2deep.py
+++ b/torch_em/shallow2deep/prepare_shallow2deep.py
@@ -421,6 +421,18 @@ def prepare_shallow2deep_advanced(
     sampler=None,
     **rf_kwargs,
 ):
+    """Advanced training of random forests for shallow2deep enhancer training.
+
+    This function accepts the 'sampling_strategy' parameter, which allows to implement custom
+    sampling strategies for the samples used for training the random forests.
+    Training operates in stages, the parameter 'forests_per_stage' determines how many forests
+    are trained in each stage, and 'sample_fraction_per_stage' which fraction of the samples is
+    taken per stage. The random forests in stage 0 are always trained from balanced dense labels.
+    For the other stages 'sampling_strategy' enables specifying the strategy; it has to be a function
+    with signature '(features, labels, forests, forests_per_stage, sample_fraction_per_stage)',
+    and return the sampled features and labels. See thw 'worst_points' function
+    in this file for an example implementation.
+    """
     os.makedirs(output_folder, exist_ok=True)
     ds, filters_and_sigmas = _prepare_shallow2deep(
         raw_paths, raw_key, label_paths, label_key,

--- a/torch_em/shallow2deep/prepare_shallow2deep.py
+++ b/torch_em/shallow2deep/prepare_shallow2deep.py
@@ -439,7 +439,6 @@ SAMPLING_STRATEGIES = {
 }
 
 
-# TODO need to incorporate the -1 ignore label
 def prepare_shallow2deep_advanced(
     raw_paths,
     raw_key,

--- a/torch_em/shallow2deep/shallow2deep_eval.py
+++ b/torch_em/shallow2deep/shallow2deep_eval.py
@@ -1,0 +1,48 @@
+import os
+import pickle
+from concurrent import futures
+from glob import glob
+
+import numpy as np
+from tqdm import tqdm
+
+from .prepare_shallow2deep import _apply_filters, _get_filters
+
+
+def visualize_pretrained_rfs(checkpoint, raw, n_forests,
+                             sample_random=False, filter_config=None, n_threads=1):
+    import napari
+
+    rf_folder = os.path.join(checkpoint, "rfs")
+    assert os.path.exists(rf_folder), rf_folder
+    rf_paths = glob(os.path.join(rf_folder, "*.pkl"))
+    rf_paths.sort()
+    if sample_random:
+        rf_paths = np.random.choice(rf_paths, size=n_forests)
+    else:
+        rf_paths = rf_paths[::(len(rf_paths) // n_forests)][:n_forests]
+
+    print("Compute features for input of shape", raw.shape)
+    filter_config = _get_filters(raw.ndim, filter_config)
+    features = _apply_filters(raw, filter_config)
+
+    def predict_rf(rf_path):
+        with open(rf_path, "rb") as f:
+            rf = pickle.load(f)
+        pred = rf.predict_proba(features)
+        pred = pred.reshape(raw.shape + (pred.shape[1],))
+        pred = np.moveaxis(pred, -1, 0)
+        assert pred.shape[1:] == raw.shape
+        return pred
+
+    with futures.ThreadPoolExecutor(n_threads) as tp:
+        preds = list(tqdm(tp.map(predict_rf, rf_paths), desc="Predict RFs", total=len(rf_paths)))
+
+    print("Start viewer")
+    v = napari.Viewer()
+    for path, pred in zip(rf_paths, preds):
+        name = os.path.basename(path)
+        v.add_image(pred, name=name)
+    v.add_image(raw)
+    v.grid.enabled = True
+    napari.run()

--- a/torch_em/shallow2deep/shallow2deep_eval.py
+++ b/torch_em/shallow2deep/shallow2deep_eval.py
@@ -2,15 +2,28 @@ import os
 import pickle
 from concurrent import futures
 from glob import glob
+from multiprocessing import cpu_count
 
 import numpy as np
-from tqdm import tqdm
+import pandas as pd
+from tqdm import tqdm, trange
 
 from .prepare_shallow2deep import _apply_filters, _get_filters
+from .shallow2deep_model import IlastikPredicter
 
 
 def visualize_pretrained_rfs(checkpoint, raw, n_forests,
-                             sample_random=False, filter_config=None, n_threads=1):
+                             sample_random=False, filter_config=None, n_threads=None):
+    """Visualize pretrained random forests from a shallow2depp checkpoint.
+
+    Arguments:
+        checkpoint [str] - path to the checkpoint folder
+        raw [np.ndarray] - the raw data for prediction
+        n_forests [int] - the number of forests to use
+        sample_random [bool] - whether to subsample forests randomly or regularly (default: False)
+        filter_config [list] - the filter configuration (default: None)
+        n_threads [int] - number of threads for parallel prediction of forests (default: None)
+    """
     import napari
 
     rf_folder = os.path.join(checkpoint, "rfs")
@@ -35,6 +48,7 @@ def visualize_pretrained_rfs(checkpoint, raw, n_forests,
         assert pred.shape[1:] == raw.shape
         return pred
 
+    n_threads = cpu_count() if n_threads is None else n_threads
     with futures.ThreadPoolExecutor(n_threads) as tp:
         preds = list(tqdm(tp.map(predict_rf, rf_paths), desc="Predict RFs", total=len(rf_paths)))
 
@@ -46,3 +60,107 @@ def visualize_pretrained_rfs(checkpoint, raw, n_forests,
     v.add_image(raw)
     v.grid.enabled = True
     napari.run()
+
+
+def evaluate_enhancers(data, labels, enhancers, ilastik_projects, metric,
+                       postprocess_rf=None, postprocess_enhancer=None,
+                       prediction_function=None,
+                       rf_channel=1, is2d=False, view=False):
+    """Evaluate enhancers on ilastik random forests from multiple projects.
+
+    Arguments:
+        data [np.ndarray] - the data for evaluation
+        labels [np.ndarray] - the labels for evaluation
+        enhancers [dict[str, str] - map of enhancer names to filepath with enhancer
+            models saved in the biomage.io model format
+        ilastik_projects [dict[str, str]] - map of names to ilastik project paths
+        metric [callable] - the metric used for evaluation
+        postprocess_rf [callable] - function to postprocess the random forest predictions
+            before evaluation (default: None)
+        postprocess_enhancer [callable] - function to postprocess the enhancer predictions
+            before evaluation (default: None)
+        prediction_function [callable] - function to run prediction with the enhancer.
+            By default the bioimageio.prediction pipeline is called directly.
+            If given, needs to take the prediction pipeline and data (as xarray)
+            as input (default: None)
+        rf_channel [[int, list[int]]] - the channel(s) of the random forest to be passed
+            as input to the enhancer (default: 1)
+        is2d [bool] - whether to process 3d data as individual slices and average the scores.
+            Is ignored if the data is 2d (default: False)
+        view [bool] - whether to view the data and predictions (default: False)
+    Returns:
+        [pd.DataFrame] - a table with the scores of the enhancers for the different forests
+            and scores of the raw forest predictions
+    """
+    import bioimageio.core
+    import xarray
+
+    assert data.shape == labels.shape
+    ndim = data.ndim
+    model_ndim = 2 if (data.ndim == 2 or is2d) else 3
+
+    def load_enhancer(enh):
+        model = bioimageio.core.load_resource_description(enh)
+        return bioimageio.core.create_prediction_pipeline(model)
+
+    # load the enhancers
+    models = {name: load_enhancer(enh) for name, enh in enhancers.items()}
+
+    # load the ilps
+    ilps = {
+        name: IlastikPredicter(path, model_ndim, ilastik_multi_thread=True, output_channel=rf_channel)
+        for name, path in ilastik_projects.items()
+    }
+
+    def process_chunk(x, y, axes):
+        predictions = {}
+        scores = np.zeros((len(models) + 1, len(ilps)))
+        for i, (rf_name, ilp) in enumerate(ilps.items()):
+            rf_pred = ilp(x)
+            predictions[rf_name] = rf_pred
+            if rf_pred.ndim == model_ndim:
+                rf_pred = xarray.DataArray(rf_pred[None, None], dims=("b", "c",) + tuple(axes))
+            else:
+                rf_pred = xarray.DataArray(rf_pred[None], dims=("b",) + tuple(axes))
+
+            for j, (enh_name, enh) in enumerate(models.items()):
+                pred = enh(rf_pred) if prediction_function is None else prediction_function(enh, rf_pred)
+                pred = pred[0][0]
+                predictions[f"{rf_name}-{enh_name}"] = pred
+                if postprocess_enhancer:
+                    pred = postprocess_enhancer(pred)
+                score = metric(pred, y)
+                scores[j, i] = score
+
+            if postprocess_rf:
+                rf_pred = postprocess_rf(rf_pred)
+            score = metric(rf_pred, y)
+            scores[-1, i] = score
+
+        scores = pd.DataFrame(scores, columns=list(ilps.keys()))
+        scores.insert(loc=0, column="enhancer", value=list(models.keys()) + ["rf-score"])
+        return scores, predictions
+
+    # if we have 2d data, or 3d data that is processed en block,
+    # we only have to process a single 'chunk'
+    if ndim == 2 or (ndim == 3 and not is2d):
+        scores, predictions = process_chunk(data, labels, "yx" if ndim == 2 else "zyx")
+    elif ndim == 3 and is2d:
+        scores = []
+        for z in trange(data.shape[0]):
+            scores_z, predictions = process_chunk(data[z], labels[z], "yx")
+            scores.append(scores_z)
+        scores = pd.concat(scores).groupby("enhancer").mean()
+    else:
+        raise ValueError("Invalid data dimensions: {ndim}")
+
+    if view:
+        import napari
+        v = napari.Viewer()
+        v.add_image(data[-1] if (ndim == 3 and is2d) else data, name="data")
+        for name, pred in predictions.items():
+            v.add_image(pred, name=name)
+        v.add_labels(labels[-1] if (ndim == 3 and is2d) else labels, name="labels")
+        napari.run()
+
+    return scores


### PR DESCRIPTION
Hey @JonasHell @k-dominik, @akreshuk
I have implemented a training routine for random forests for shallow 2 deep here that trains RFs in stages, and selects the training examples for each stage by taking the worst predictions from forests from the previous stage, similar to what we discussed during the retreat. This is implemented with `prepare_shallow2deep_advanced` by adding a `sampling_strategy` parameter that enables customizing the sampling of random forest training samples. (And using the strategy described above by default).

I will train a RF for mito segmentation based on this shortly and share it, to see if it improves results. And if you have other sampling strategies (e.g. sampling scribbles instead of points), we could eventually think about adding them here.

In more detail, here''s how the `sampling_strategy` is implemented (copied from the docstring):
```
    This function accepts the 'sampling_strategy' parameter, which allows to implement custom
    sampling strategies for the samples used for training the random forests.
    Training operates in stages, the parameter 'forests_per_stage' determines how many forests
    are trained in each stage, and 'sample_fraction_per_stage' which fraction of the samples is
    taken per stage. The random forests in stage 0 are always trained from balanced dense labels.
    For the other stages 'sampling_strategy' enables specifying the strategy; it has to be a function
    with signature '(features, labels, forests, forests_per_stage, sample_fraction_per_stage)',
    and return the sampled features and labels. See thw 'worst_points' function
    in this file for an example implementation.
```