### PR TITLE
adapt _serialize_feature_config() to work with strings

### DIFF
--- a/torch_em/shallow2deep/prepare_shallow2deep.py
+++ b/torch_em/shallow2deep/prepare_shallow2deep.py
@@ -340,8 +340,9 @@ def _prepare_shallow2deep(
 
 def _serialize_feature_config(filters_and_sigmas):
     feature_config = [
-        (filt.func.__name__ if isinstance(filt, partial) else filt.__name__,
-         sigma)
+        (filt if isinstance(filt, str)
+            else (filt.func.__name__ if isinstance(filt, partial) else filt.__name__),
+        sigma)
         for filt, sigma in filters_and_sigmas
     ]
     return feature_config


### PR DESCRIPTION
I think there is no additional check needed since `_apply_filters()` already checks if a function with this name exists, and it is called before `_serialize_feature_config()`