### PR TITLE
provide reasonable default values for augmentations

### DIFF
--- a/torch_em/transform/raw.py
+++ b/torch_em/transform/raw.py
@@ -86,12 +86,13 @@ def normalize_percentile(raw, lower=1.0, upper=99.0, axis=None, eps=1e-7):
 #
 # intensity augmentations / noise augmentations
 #
+
 # modified from https://github.com/kreshuklab/spoco/blob/main/spoco/transforms.py
 class RandomContrast():
     """
     Adjust contrast by scaling image to `mean + alpha * (image - mean)`.
     """
-    def __init__(self, alpha=(0.5, 1.5), mean=0.0, clip_kwargs={}): # {'a_min': 0, 'a_max': 1}):
+    def __init__(self, alpha=(0.05, 4), mean=0.5, clip_kwargs={'a_min': 0, 'a_max': 1}):
         self.alpha = alpha
         self.mean = mean
         self.clip_kwargs = clip_kwargs
@@ -108,7 +109,7 @@ class AdditiveGaussianNoise():
     """
     Add random Gaussian noise to image.
     """
-    def __init__(self, scale=(0.0, 1.0)):
+    def __init__(self, scale=(0.0, 0.75)):
         self.scale = scale
 
     def __call__(self, img):
@@ -121,13 +122,29 @@ class AdditivePoissonNoise():
     """
     Add random Poisson noise to image.
     """
-    def __init__(self, lam=(0.0, 1.0)):
+    def __init__(self, lam=(0.0, 0.75)):
         self.lam = lam
 
     def __call__(self, img):
         lam = np.random.uniform(self.lam[0], self.lam[1])
         poisson_noise = np.random.poisson(lam, size=img.shape)
         return img + poisson_noise
+
+
+class GaussianBlur():
+    """
+    Blur the image.
+    """
+    def __init__(self, kernel_size=(2, 24), sigma=(0, 5)):
+        self.kernel_size = kernel_size
+        self.sigma = sigma
+
+    def __call__(self, img):
+        # sample kernel_size and make sure it is odd
+        kernel_size = 2 * (np.random.randint(self.kernel_size[0], self.kernel_size[1]) // 2) + 1
+        # switch boundaries to make sure 0 is excluded from sampling
+        sigma = np.random.uniform(self.sigma[1], self.sigma[0])
+        return transforms.GaussianBlur(kernel_size, sigma=sigma)(img)
 
 
 #
@@ -156,18 +173,18 @@ def get_raw_transform(normalizer=standardize, augmentation1=None, augmentation2=
                         augmentation2=augmentation2)
 
 
+# The default values are made for an image with pixel values in
+# range [0, 1]. That the image is in this range is ensured by an
+# initial normalizations step.
 def get_default_mean_teacher_augmentations(p=0.5):
     norm = normalize
     aug1 = transforms.Compose([
-        transforms.RandomApply(
-            [transforms.GaussianBlur(kernel_size=5, sigma=(0.1, 2.0))], p=p
-        ),
+        normalize,
+        transforms.RandomApply([GaussianBlur()], p=p),
         transforms.RandomApply([AdditiveGaussianNoise()], p=p),
         transforms.RandomApply([AdditivePoissonNoise()], p=p)
     ])
-    aug2 = transforms.RandomApply(
-        [RandomContrast(clip_kwargs={'a_min': 0, 'a_max': 1})], p=p
-    )
+    aug2 = transforms.RandomApply([RandomContrast()], p=p)
     return get_raw_transform(
         normalizer=norm,
         augmentation1=aug1,


### PR DESCRIPTION
- updated all the default values to a more reasonable range
- everything works for [0, 1]-range images
- add GaussianBlur class to allow for random kernel_size and sigma