### PR TITLE
Fixes and Updates for UNETR

### DIFF
--- a/experiments/vision-transformer/unetr/README.md
+++ b/experiments/vision-transformer/unetr/README.md
@@ -1,0 +1,13 @@
+## Usage of SAM's ViT initialization in UNETR
+
+### Initialize ViT models for UNETR
+```
+from torch_em.model import UNETR
+unetr = UNETR(encoder=model_type, out_channels=out_channels, encoder_checkpoint_path=checkpoint_path)
+```
+
+### Vanilla ViT models for UNETR
+```
+from torch_em.model import UNETR
+unetr = UNETR(encoder=model_type, out_channels=out_channels)
+```

--- a/experiments/vision-transformer/unetr/README.md
+++ b/experiments/vision-transformer/unetr/README.md
@@ -1,6 +1,12 @@
-## Usage of SAM's ViT initialization in UNETR
+## SAM's ViT Initialization in UNETR
 
-### Initialize ViT models for UNETR
+Note:
+- `model_type` - [`vit_b`/`vit_l`/`vit_h`]
+- `out_channels` - Number of output channels
+- `encoder_checkpoint_path` - Pass the checkpoints from the pretrained [Segment Anything](https://github.com/facebookresearch/segment-anything) models to initialize the SAM weights to the (ViT) encoder backbone (Click on the model names to download them - [ViT-b](https://dl.fbaipublicfiles.com/segment_anything/sam_vit_b_01ec64.pth) / [ViT-l](https://dl.fbaipublicfiles.com/segment_anything/sam_vit_l_0b3195.pth) / [ViT-h](https://dl.fbaipublicfiles.com/segment_anything/sam_vit_h_4b8939.pth)) 
+
+
+### How to initialize ViT models for UNETR?
 ```
 from torch_em.model import UNETR
 unetr = UNETR(encoder=model_type, out_channels=out_channels, encoder_checkpoint_path=checkpoint_path)

--- a/experiments/vision-transformer/unetr/cremi_unetr.py
+++ b/experiments/vision-transformer/unetr/cremi_unetr.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import torch
 import torch_em
-from torch_em.model.unetr import build_unetr_with_sam_initialization
+from torch_em.model import UNETR
 from torch_em.data.datasets import get_cremi_loader
 
 
@@ -34,9 +34,9 @@ def do_unetr_training(data_path: str, save_root: str, iterations: int, device, p
         batch_size=1
     )
 
-    model = build_unetr_with_sam_initialization(
-        checkpoint_path="/scratch/usr/nimanwai/models/segment-anything/checkpoints/sam_vit_b_01ec64.pth"
-    )
+    model = UNETR(
+        encoder="vit_b", out_channels=1,
+        encoder_checkpoint_path="/scratch/usr/nimanwai/models/segment-anything/checkpoints/sam_vit_b_01ec64.pth")
     model.to(device)
 
     trainer = torch_em.default_segmentation_trainer(

--- a/experiments/vision-transformer/unetr/cremi_unetr.py
+++ b/experiments/vision-transformer/unetr/cremi_unetr.py
@@ -1,44 +1,46 @@
 import os
 import argparse
+import numpy as np
 
 import torch
 import torch_em
 from torch_em.model.unetr import build_unetr_with_sam_initialization
-from torch_em.data.datasets import get_livecell_loader
+from torch_em.data.datasets import get_cremi_loader
 
 
-def do_unetr_training(data_path: str, save_root: str, cell_type: list, iterations: int, device, patch_shape=(256, 256)):
+def do_unetr_training(data_path: str, save_root: str, iterations: int, device, patch_shape=(1, 512, 512)):
     os.makedirs(data_path, exist_ok=True)
-    train_loader = get_livecell_loader(
+
+    cremi_train_rois = {"A": np.s_[0:75, :, :], "B": np.s_[0:75, :, :], "C": np.s_[0:75, :, :]}
+    cremi_val_rois = {"A": np.s_[75:100, :, :], "B": np.s_[75:100, :, :], "C": np.s_[75:100, :, :]}
+
+    train_loader = get_cremi_loader(
         path=data_path,
-        split="train",
-        patch_shape=patch_shape,
-        batch_size=2,
-        cell_types=cell_type,
-        download=True,
-        boundaries=True
+        patch_shape=patch_shape, download=True,
+        rois=cremi_train_rois,
+        ndim=2,
+        defect_augmentation_kwargs=None,
+        boundaries=True,
+        batch_size=2
     )
 
-    val_loader = get_livecell_loader(
+    val_loader = get_cremi_loader(
         path=data_path,
-        split="val",
-        patch_shape=patch_shape,
-        batch_size=1,
-        cell_types=cell_type,
-        download=True,
-        boundaries=True
+        patch_shape=patch_shape, download=True,
+        rois=cremi_val_rois,
+        ndim=2,
+        defect_augmentation_kwargs=None,
+        boundaries=True,
+        batch_size=1
     )
-
-    n_channels = 2
 
     model = build_unetr_with_sam_initialization(
-        out_channels=n_channels,
         checkpoint_path="/scratch/usr/nimanwai/models/segment-anything/checkpoints/sam_vit_b_01ec64.pth"
     )
     model.to(device)
 
     trainer = torch_em.default_segmentation_trainer(
-        name=f"unetr-source-livecell-{cell_type[0]}",
+        name="unetr-cremi",
         model=model,
         train_loader=train_loader,
         val_loader=val_loader,
@@ -57,11 +59,10 @@ def main(args):
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
     if args.train:
-        print("Training a 2D UNETR on LiveCell dataset")
+        print("Training a 2D UNETR on Cremi dataset")
         do_unetr_training(
             data_path=args.inputs,
             save_root=args.save_root,
-            cell_type=args.cell_type,
             iterations=args.iterations,
             device=device
         )
@@ -69,10 +70,8 @@ def main(args):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--train", action='store_true', help="Enables UNETR training on LiveCELL dataset")
-    parser.add_argument("-c", "--cell_type", nargs='+', default=["A172"],
-                        help="Choice of cell-type for doing the training")
-    parser.add_argument("-i", "--inputs", type=str, default="./livecell/",
+    parser.add_argument("--train", action='store_true', help="Enables UNETR training on Cremi dataset")
+    parser.add_argument("-i", "--inputs", type=str, default="./cremi/",
                         help="Path where the dataset already exists/will be downloaded by the dataloader")
     parser.add_argument("-s", "--save_root", type=str, default=None,
                         help="Path where checkpoints and logs will be saved")

--- a/experiments/vision-transformer/unetr/initialize_with_sam.py
+++ b/experiments/vision-transformer/unetr/initialize_with_sam.py
@@ -5,7 +5,8 @@ from torch_em.model.unetr import build_unetr_with_sam_initialization
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 model = build_unetr_with_sam_initialization(
-    checkpoint_path="/scratch/usr/nimanwai/models/segment-anything/checkpoints/sam_vit_b_01ec64.pth")
+    model_type="vit_h",
+    checkpoint_path="/scratch/usr/nimanwai/models/segment-anything/checkpoints/sam_vit_h_4b8939.pth")
 model.to(device)
 
 x = torch.randn(1, 3, 1024, 1024).to(device=device)

--- a/experiments/vision-transformer/unetr/initialize_with_sam.py
+++ b/experiments/vision-transformer/unetr/initialize_with_sam.py
@@ -1,12 +1,10 @@
 import torch
-from torch_em.model.unetr import build_unetr_with_sam_initialization
+from torch_em.model import UNETR
 
-# FIXME this doesn't work yet
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-model = build_unetr_with_sam_initialization(
-    model_type="vit_h",
-    checkpoint_path="/scratch/usr/nimanwai/models/segment-anything/checkpoints/sam_vit_h_4b8939.pth")
+model = UNETR(encoder="vit_h", out_channels=1,
+              encoder_checkpoint_path="/scratch/usr/nimanwai/models/segment-anything/checkpoints/sam_vit_h_4b8939.pth")
 model.to(device)
 
 x = torch.randn(1, 3, 1024, 1024).to(device=device)

--- a/experiments/vision-transformer/unetr/initialize_with_sam.py
+++ b/experiments/vision-transformer/unetr/initialize_with_sam.py
@@ -1,9 +1,14 @@
 import torch
-from torch_em.model.unetr import build_unetr_with_sam_intialization
+from torch_em.model.unetr import build_unetr_with_sam_initialization
 
 # FIXME this doesn't work yet
-model = build_unetr_with_sam_intialization()
-x = torch.randn(1, 3, 1024, 1024)
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+model = build_unetr_with_sam_initialization(
+    checkpoint_path="/scratch/usr/nimanwai/models/segment-anything/checkpoints/sam_vit_b_01ec64.pth")
+model.to(device)
+
+x = torch.randn(1, 3, 1024, 1024).to(device=device)
 
 y = model(x)
 print(y.shape)

--- a/experiments/vision-transformer/unetr/livecell_unetr.py
+++ b/experiments/vision-transformer/unetr/livecell_unetr.py
@@ -3,7 +3,7 @@ import argparse
 
 import torch
 import torch_em
-from torch_em.model.unetr import build_unetr_with_sam_initialization
+from torch_em.model import UNETR
 from torch_em.data.datasets import get_livecell_loader
 
 
@@ -31,10 +31,9 @@ def do_unetr_training(data_path: str, save_root: str, cell_type: list, iteration
 
     n_channels = 2
 
-    model = build_unetr_with_sam_initialization(
-        out_channels=n_channels,
-        checkpoint_path="/scratch/usr/nimanwai/models/segment-anything/checkpoints/sam_vit_b_01ec64.pth"
-    )
+    model = UNETR(
+        encoder="vit_b", out_channels=n_channels,
+        encoder_checkpoint_path="/scratch/usr/nimanwai/models/segment-anything/checkpoints/sam_vit_b_01ec64.pth")
     model.to(device)
 
     trainer = torch_em.default_segmentation_trainer(

--- a/torch_em/model/__init__.py
+++ b/torch_em/model/__init__.py
@@ -1,3 +1,3 @@
 from .unet import AnisotropicUNet, UNet2d, UNet3d
 from .probabilistic_unet import ProbabilisticUNet
-from .unetr import UNETR, build_unetr_with_sam_initialization
+from .unetr import UNETR

--- a/torch_em/model/__init__.py
+++ b/torch_em/model/__init__.py
@@ -1,3 +1,3 @@
 from .unet import AnisotropicUNet, UNet2d, UNet3d
 from .probabilistic_unet import ProbabilisticUNet
-from .unetr import UNETR, build_unetr_with_sam_intialization
+from .unetr import UNETR, build_unetr_with_sam_initialization

--- a/torch_em/model/unetr.py
+++ b/torch_em/model/unetr.py
@@ -39,7 +39,7 @@ class ViT_Sam(ImageEncoderViT):
                 "and then rerun your code."
             )
 
-        super().__init__(**kwargs)
+        super().__init__(embed_dim=embed_dim, **kwargs)
         self.chunks_for_projection = global_attn_indexes
         self.in_chans = in_chans
         self.embed_dim = embed_dim

--- a/torch_em/model/unetr.py
+++ b/torch_em/model/unetr.py
@@ -21,7 +21,7 @@ except ImportError:
     get_sam_model = None
 
 
-class ViT_Sam(ImageEncoderViT):
+class ViT_Sam(ImageEncoderViT):  # type: ignore
     """Vision Transformer derived from the Segment Anything Codebase (https://arxiv.org/abs/2304.02643):
     https://github.com/facebookresearch/segment-anything/blob/main/segment_anything/modeling/image_encoder.py
     """
@@ -116,8 +116,7 @@ class UNETR(nn.Module):
         decoder=None,
         out_channels=1,
         use_sam_preprocessing=True,
-        initialize_from_sam=False,
-        checkpoint_path=None
+        encoder_checkpoint_path=None
     ) -> None:
         depth = 3
         initial_features = 64
@@ -178,13 +177,12 @@ class UNETR(nn.Module):
             )
 
         else:
-            raise NotImplementedError
+            raise ValueError(f"{encoder} is not supported. Currently only vit_b, vit_l, vit_h are supported.")
 
-        if initialize_from_sam:
-            assert checkpoint_path is not None
+        if encoder_checkpoint_path is not None:
             _, model = get_sam_model(
                 model_type=encoder,
-                checkpoint_path=checkpoint_path,
+                checkpoint_path=encoder_checkpoint_path,
                 return_sam=True
             )  # type: ignore
             for param1, param2 in zip(model.parameters(), self.encoder.parameters()):
@@ -322,14 +320,3 @@ class Deconv2DBlock(nn.Module):
 
     def forward(self, x):
         return self.block(x)
-
-
-def build_unetr_with_sam_initialization(out_channels=1, model_type="vit_b", checkpoint_path=None):
-    unetr = UNETR(encoder=model_type, out_channels=out_channels,
-                  initialize_from_sam=True, checkpoint_path=checkpoint_path)
-    return unetr
-
-
-def build_unetr_without_sam_initialization(out_channels=1, model_type="vit_b"):
-    unetr = UNETR(encoder=model_type, out_channels=out_channels)
-    return unetr


### PR DESCRIPTION
I checked up for UNETR, and tried to fix the overalls (one final thing is still missing - the switch between ViT models)

To address some previous questions - 
- We do the preprocessing for the inputs to make sure that the dimensions are as SAM's ViT appreciates (1024 * 1024)
- The initialization of SAM works now (the parameters are getting updated)
- Added training script for Cremi (and updated for LiveCell)

In general, UNETR models can now be called from two obvious functions super easily (`from torch_em.model import build_unetr_with_sam_initialization, build_unetr_without_sam_initialization`) (not 100% of the nomenclature though)