### PR TITLE
Update UNETR to enable resize to longest side

### DIFF
--- a/test/model/test_unetr.py
+++ b/test/model/test_unetr.py
@@ -26,14 +26,24 @@ class TestUnetr(unittest.TestCase):
         from torch_em.model import UNETR
 
         model = UNETR()
-        self._test_net(model, (1, 3, 256, 256))
+        self._test_net(model, (1, 3, 512, 512))
+
+    def test_unetr_no_resize(self):
+        from torch_em.model import UNETR
+
+        model = UNETR(resize_input=False)
+        self._test_net(model, (1, 3, 512, 512))
 
     @unittest.skipIf(micro_sam is None, "Needs micro_sam")
     def test_unetr_from_sam(self):
-        from torch_em.model import build_unetr_with_sam_intialization
+        from torch_em.model import UNETR
+        from micro_sam.util import models
 
-        model = build_unetr_with_sam_intialization()
-        self._test_net(model, (1, 3, 256, 256))
+        model_registry = models()
+        checkpoint = model_registry.fetch("vit_b")
+
+        model = UNETR(encoder_checkpoint=checkpoint)
+        self._test_net(model, (1, 3, 512, 512))
 
 
 if __name__ == "__main__":

--- a/torch_em/model/unetr.py
+++ b/torch_em/model/unetr.py
@@ -175,8 +175,8 @@ class UNETR(nn.Module):
             # TODO: add mean std from mae experiments (or open up arguments for this)
             raise NotImplementedError
         else:
-            pixel_mean = torch.Tensor([0.0, 0.0, 0.0]).view(-1, 1, 1).to(device)
-            pixel_std = torch.Tensor([1.0, 1.0, 1.0]).view(-1, 1, 1).to(device)
+            pixel_mean = torch.Tensor([0.0, 0.0, 0.0]).view(1, -1, 1, 1).to(device)
+            pixel_std = torch.Tensor([1.0, 1.0, 1.0]).view(1, -1, 1, 1).to(device)
 
         transform = getattr(self, "transform", None)
         if transform is not None:

--- a/torch_em/model/unetr.py
+++ b/torch_em/model/unetr.py
@@ -179,7 +179,7 @@ class UNETR(nn.Module):
             pixel_std = torch.Tensor([1.0, 1.0, 1.0]).view(-1, 1, 1).to(device)
 
         transform = getattr(self, "transform", None)
-        if transform is None:
+        if transform is not None:
             x = transform.apply_image_torch(x)
         input_shape = x.shape[-2:]
 


### PR DESCRIPTION
to enable consistency with SAM and use full encoder input shape rather than naively padding.

This is still a draft to discuss what the best default is and how we can best integrate this with previous code.