### PR TITLE
Restore old norm layer defaults

### DIFF
--- a/torch_em/model/unet.py
+++ b/torch_em/model/unet.py
@@ -353,10 +353,10 @@ def get_norm_layer(norm, dim, channels, n_groups=32):
     if norm is None:
         return None
     if norm == "InstanceNorm":
+        return nn.InstanceNorm2d(channels) if dim == 2 else nn.InstanceNorm3d(channels)
+    elif norm == "InstanceNormTrackStats":
         kwargs = {"affine": True, "track_running_stats": True, "momentum": 0.01}
         return nn.InstanceNorm2d(channels, **kwargs) if dim == 2 else nn.InstanceNorm3d(channels, **kwargs)
-    elif norm == "OldDefault":
-        return nn.InstanceNorm2d(channels) if dim == 2 else nn.InstanceNorm3d(channels)
     elif norm == "GroupNorm":
         return nn.GroupNorm(min(n_groups, channels), channels)
     elif norm == "BatchNorm":


### PR DESCRIPTION
I am restoring the old default for the normalization layer, given that tracking the stats leads to a decrease in segmentation quality.

cc @anwai98 