### PR TITLE
Update legacy editable install for torch_em

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=64.0", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
While doing editable installs using pip, it returns a depreciation warning stating:
> DEPRECATION: Legacy editable install of torch_em==0.7.3 from file:///home/nimanwai/torch-em (setup.py develop) is deprecated. pip 25.0 will enforce this behaviour change. A possible replacement is to add a pyproject.toml or enable --use-pep517, and use setuptools >= 64. If the resulting installation is not behaving as expected, try using --config-settings editable_mode=compat. Please consult the setuptools documentation for more information. Discussion can be found at https://github.com/pypa/pip/issues/11457

Hence, adding `pyproject.toml` in favor of updating the legacy editable installation of the package from source.