### PR TITLE
Minor update to load_model: Support loading directly from checkpoint

### DIFF
--- a/torch_em/data/datasets/__init__.py
+++ b/torch_em/data/datasets/__init__.py
@@ -1,4 +1,5 @@
 from .electron_microscopy import *
 from .histopathology import *
 from .light_microscopy import *
+from .medical import *
 from .util import get_bioimageio_dataset_id

--- a/torch_em/util/util.py
+++ b/torch_em/util/util.py
@@ -277,7 +277,11 @@ def load_model(checkpoint, model=None, name="best", state_key="model_state", dev
         model = get_trainer(checkpoint, name=name, device=device).model
 
     else:  # load the model state from the checkpoint
-        ckpt = os.path.join(checkpoint, f"{name}.pt")
+        if os.path.isdir(checkpoint):
+            ckpt = os.path.join(checkpoint, f"{name}.pt")
+        else:
+            ckpt = checkpoint
+
         state = torch.load(ckpt, map_location=device)[state_key]
         # to enable loading compiled models
         compiled_prefix = "_orig_mod."


### PR DESCRIPTION
I think this addition would make the model loading quite flexible, regardless of using the directory where checkpoints are stored or directly the checkpoints.