### PR TITLE
Set non_blocking to True for tensor device allocation

### DIFF
--- a/torch_em/segmentation.py
+++ b/torch_em/segmentation.py
@@ -318,8 +318,6 @@ def default_segmentation_dataset(
 
 def get_data_loader(dataset: torch.utils.data.Dataset, batch_size: int, **loader_kwargs) -> torch.utils.data.DataLoader:
     pin_memory = loader_kwargs.pop("pin_memory", True)
-    print(pin_memory)
-    breakpoint()
     loader = torch.utils.data.DataLoader(dataset, batch_size=batch_size, pin_memory=pin_memory, **loader_kwargs)
     # monkey patch shuffle attribute to the loader
     loader.shuffle = loader_kwargs.get("shuffle", False)

--- a/torch_em/segmentation.py
+++ b/torch_em/segmentation.py
@@ -316,8 +316,11 @@ def default_segmentation_dataset(
     return ds
 
 
-def get_data_loader(dataset: torch.utils.data.Dataset, batch_size, **loader_kwargs) -> torch.utils.data.DataLoader:
-    loader = torch.utils.data.DataLoader(dataset, batch_size=batch_size, **loader_kwargs)
+def get_data_loader(dataset: torch.utils.data.Dataset, batch_size: int, **loader_kwargs) -> torch.utils.data.DataLoader:
+    pin_memory = loader_kwargs.pop("pin_memory", True)
+    print(pin_memory)
+    breakpoint()
+    loader = torch.utils.data.DataLoader(dataset, batch_size=batch_size, pin_memory=pin_memory, **loader_kwargs)
     # monkey patch shuffle attribute to the loader
     loader.shuffle = loader_kwargs.get("shuffle", False)
     return loader

--- a/torch_em/self_training/fix_match.py
+++ b/torch_em/self_training/fix_match.py
@@ -183,7 +183,7 @@ class FixMatchTrainer(torch_em.trainer.DefaultTrainer):
 
         # Sample from both the supervised and unsupervised loader.
         for xu1, xu2 in self.unsupervised_train_loader:
-            xu1, xu2 = xu1.to(self.device), xu2.to(self.device)
+            xu1, xu2 = xu1.to(self.device, non_blocking=True), xu2.to(self.device, non_blocking=True)
 
             teacher_input, model_input = xu1, xu2
 
@@ -231,8 +231,8 @@ class FixMatchTrainer(torch_em.trainer.DefaultTrainer):
 
         # Sample from both the supervised and unsupervised loader.
         for (xs, ys), (xu1, xu2) in zip(self.supervised_train_loader, self.unsupervised_train_loader):
-            xs, ys = xs.to(self.device), ys.to(self.device)
-            xu1, xu2 = xu1.to(self.device), xu2.to(self.device)
+            xs, ys = xs.to(self.device, non_blocking=True), ys.to(self.device, non_blocking=True)
+            xu1, xu2 = xu1.to(self.device, non_blocking=True), xu2.to(self.device, non_blocking=True)
 
             # Perform supervised training.
             self.optimizer.zero_grad()
@@ -289,7 +289,7 @@ class FixMatchTrainer(torch_em.trainer.DefaultTrainer):
         loss_val = 0.0
 
         for x, y in self.supervised_val_loader:
-            x, y = x.to(self.device), y.to(self.device)
+            x, y = x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
             with forward_context():
                 loss, metric = self.supervised_loss_and_metric(self.model, x, y)
             loss_val += loss.item()
@@ -310,7 +310,7 @@ class FixMatchTrainer(torch_em.trainer.DefaultTrainer):
         loss_val = 0.0
 
         for x1, x2 in self.unsupervised_val_loader:
-            x1, x2 = x1.to(self.device), x2.to(self.device)
+            x1, x2 = x1.to(self.device, non_blocking=True), x2.to(self.device, non_blocking=True)
             teacher_input, model_input = x1, x2
             with forward_context():
                 pseudo_labels, label_filter = self.pseudo_labeler(self.model, teacher_input)

--- a/torch_em/self_training/mean_teacher.py
+++ b/torch_em/self_training/mean_teacher.py
@@ -213,7 +213,7 @@ class MeanTeacherTrainer(torch_em.trainer.DefaultTrainer):
 
         # Sample from both the supervised and unsupervised loader.
         for xu1, xu2 in self.unsupervised_train_loader:
-            xu1, xu2 = xu1.to(self.device), xu2.to(self.device)
+            xu1, xu2 = xu1.to(self.device, non_blocking=True), xu2.to(self.device, non_blocking=True)
 
             teacher_input, model_input = xu1, xu2
 
@@ -256,8 +256,8 @@ class MeanTeacherTrainer(torch_em.trainer.DefaultTrainer):
 
         # Sample from both the supervised and unsupervised loader.
         for (xs, ys), (xu1, xu2) in zip(self.supervised_train_loader, self.unsupervised_train_loader):
-            xs, ys = xs.to(self.device), ys.to(self.device)
-            xu1, xu2 = xu1.to(self.device), xu2.to(self.device)
+            xs, ys = xs.to(self.device, non_blocking=True), ys.to(self.device, non_blocking=True)
+            xu1, xu2 = xu1.to(self.device, non_blocking=True), xu2.to(self.device, non_blocking=True)
 
             # Perform supervised training.
             self.optimizer.zero_grad()
@@ -310,7 +310,7 @@ class MeanTeacherTrainer(torch_em.trainer.DefaultTrainer):
         loss_val = 0.0
 
         for x, y in self.supervised_val_loader:
-            x, y = x.to(self.device), y.to(self.device)
+            x, y = x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
             with forward_context():
                 loss, metric = self.supervised_loss_and_metric(self.model, x, y)
             loss_val += loss.item()
@@ -331,7 +331,7 @@ class MeanTeacherTrainer(torch_em.trainer.DefaultTrainer):
         loss_val = 0.0
 
         for x1, x2 in self.unsupervised_val_loader:
-            x1, x2 = x1.to(self.device), x2.to(self.device)
+            x1, x2 = x1.to(self.device, non_blocking=True), x2.to(self.device, non_blocking=True)
             teacher_input, model_input = x1, x2
             with forward_context():
                 pseudo_labels, label_filter = self.pseudo_labeler(self.teacher, teacher_input)

--- a/torch_em/self_training/probabilistic_unet_trainer.py
+++ b/torch_em/self_training/probabilistic_unet_trainer.py
@@ -59,7 +59,7 @@ class ProbabilisticUNetTrainer(torch_em.trainer.DefaultTrainer):
         t_per_iter = time.time()
 
         for x, y in self.train_loader:
-            x, y = x.to(self.device), y.to(self.device)
+            x, y = x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
 
             self.optimizer.zero_grad()
 
@@ -96,7 +96,7 @@ class ProbabilisticUNetTrainer(torch_em.trainer.DefaultTrainer):
 
         with torch.no_grad():
             for x, y in self.val_loader:
-                x, y = x.to(self.device), y.to(self.device)
+                x, y = x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
 
                 with forward_context():
                     loss, metric = self.loss_and_metric(self.model, x, y)

--- a/torch_em/trainer/default_trainer.py
+++ b/torch_em/trainer/default_trainer.py
@@ -667,7 +667,7 @@ class DefaultTrainer:
         n_iter = 0
         t_per_iter = time.time()
         for x, y in self.train_loader:
-            x, y = x.to(self.device), y.to(self.device)
+            x, y = x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
 
             self.optimizer.zero_grad()
 
@@ -705,7 +705,7 @@ class DefaultTrainer:
 
         with torch.no_grad():
             for x, y in self.val_loader:
-                x, y = x.to(self.device), y.to(self.device)
+                x, y = x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
                 with forward_context():
                     pred, loss = self._forward_and_loss(x, y)
                     metric = self.metric(pred, y)

--- a/torch_em/trainer/spoco_trainer.py
+++ b/torch_em/trainer/spoco_trainer.py
@@ -56,7 +56,7 @@ class SPOCOTrainer(DefaultTrainer):
         )
 
         for x in self.semisupervised_loader:
-            x = x.to(self.device)
+            x = x.to(self.device, non_blocking=True)
             self.optimizer.zero_grad()
 
             with forward_context():
@@ -76,7 +76,7 @@ class SPOCOTrainer(DefaultTrainer):
         n_iter = 0
         t_per_iter = time.time()
         for x, y in self.train_loader:
-            x, y = x.to(self.device), y.to(self.device)
+            x, y = x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
 
             self.optimizer.zero_grad()
 
@@ -120,7 +120,7 @@ class SPOCOTrainer(DefaultTrainer):
 
         with torch.no_grad():
             for x, y in self.val_loader:
-                x, y = x.to(self.device), y.to(self.device)
+                x, y = x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
                 with forward_context():
                     prediction = self.model(x)
                     prediction2 = self.model2(x)


### PR DESCRIPTION
This PR adds `non_blocking=True` to tensor pins to `cuda` to enable asynchronous copies of objects, leading to a minor speed up.

NOTE: This only works when items originate from pinned memory, i.e. works only when the argument `pin_memory=True` is passed to the dataloader.

Reference: https://pytorch.org/docs/stable/notes/cuda.html#cuda-memory-pinning

This should in theory speed up respective trainings as well. GTG from my side. Thanks!

Closes https://github.com/constantinpape/torch-em/issues/356.