### PR TITLE
Update lizard dataset - change download to kaggle api

### DIFF
--- a/scripts/datasets/histopathology/check_lizard.py
+++ b/scripts/datasets/histopathology/check_lizard.py
@@ -1,9 +1,22 @@
+import os
+import sys
+
 from torch_em.data.datasets import get_lizard_loader
 from torch_em.util.debug import check_loader
 
 
+sys.path.append("..")
+
+
 def check_lizard():
-    loader = get_lizard_loader("./data/lizard", (512, 512), 1, download=True)
+    from util import ROOT
+
+    loader = get_lizard_loader(
+        path=os.path.join(ROOT, "lizard"),
+        patch_shape=(512, 512),
+        batch_size=1,
+        download=True
+    )
     check_loader(loader, 8, rgb=True, instance_labels=True)
 
 


### PR DESCRIPTION
Resolves https://github.com/constantinpape/torch-em/issues/343

This PR updates the following:
- Moves the download to kaggle api-based function supported by `torch-em`
- Adds docstring to the functions
- Refactors download functionality to move it under `get_lizard_data` function.

GTG from my side!