### PR TITLE
Add function in datasets to get input paths

### DIFF
--- a/torch_em/data/datasets/electron_microscopy/cem.py
+++ b/torch_em/data/datasets/electron_microscopy/cem.py
@@ -28,7 +28,7 @@ issues, so we recommend to download the data manually and then run the loaders w
 import os
 import json
 from glob import glob
-from typing import List, Tuple, Union
+from typing import List, Tuple, Union, Literal
 
 import numpy as np
 import imageio.v3 as imageio
@@ -39,6 +39,7 @@ from torch.utils.data import Dataset, DataLoader
 import torch_em
 
 from .. import util
+
 
 BENCHMARK_DATASETS = {
     1: "mito_benchmarks/c_elegans",
@@ -58,20 +59,6 @@ BENCHMARK_SHAPES = {
     6: (1260, 1081, 1200),
     7: (224, 224),  # NOTE: this is the minimal square shape that fits
 }
-
-
-def _get_mitolab_data(path, download):
-    access_id = "11037"
-    data_path = util.download_source_empiar(path, access_id, download)
-
-    zip_path = os.path.join(data_path, "data/cem_mitolab.zip")
-    if os.path.exists(zip_path):
-        util.unzip(zip_path, data_path, remove=True)
-
-    data_root = os.path.join(data_path, "cem_mitolab")
-    assert os.path.exists(data_root)
-
-    return data_root
 
 
 def _get_all_images(path):
@@ -124,14 +111,37 @@ def _get_non_empty_images(path):
     return raw_paths, label_paths
 
 
-def get_mitolab_data(
+def get_mitolab_data(path: Union[os.PathLike, str], download: bool = False) -> str:
+    """Download the MitoLab training data.
+
+    Args:
+        path: Filepath to a folder where the downloaded data will be saved.
+        download: Whether to download the data if it is not present.
+
+    Returns:
+        The filepath for the downloaded data.
+    """
+    access_id = "11037"
+    data_path = util.download_source_empiar(path, access_id, download)
+
+    zip_path = os.path.join(data_path, "data/cem_mitolab.zip")
+    if os.path.exists(zip_path):
+        util.unzip(zip_path, data_path, remove=True)
+
+    data_root = os.path.join(data_path, "cem_mitolab")
+    assert os.path.exists(data_root)
+
+    return data_root
+
+
+def get_mitolab_paths(
     path: Union[os.PathLike, str],
-    split: str,
-    val_fraction: float,
-    download: bool,
-    discard_empty_images: bool
+    split: Literal['train', 'val'],
+    val_fraction: float = 0.05,
+    download: bool = False,
+    discard_empty_images: bool = True,
 ) -> Tuple[List[str], List[str]]:
-    """Download the mitolab training data.
+    """Get the paths to MitoLab training data.
 
     Args:
         path: Filepath to a folder where the downloaded data will be saved.
@@ -144,7 +154,8 @@ def get_mitolab_data(
         List of the image data paths.
         List of the label data paths.
     """
-    data_path = _get_mitolab_data(path, download)
+    data_path = get_mitolab_data(path, download)
+
     if discard_empty_images:
         raw_paths, label_paths = _get_non_empty_images(data_path)
     else:
@@ -164,14 +175,27 @@ def get_mitolab_data(
     return raw_paths, label_paths
 
 
-def get_benchmark_data(
-    path: Union[os.PathLike, str],
-    dataset_id: int,
-    download: bool
-) -> Tuple[
-    List[str], List[str], str, str, bool
-]:
-    """Download the mitolab benchmark data.
+def get_benchmark_data(path: Union[os.PathLike, str], dataset_id: int, download: bool = False) -> str:
+    """Download the MitoLab benchmark data.
+
+    Args:
+        path: Filepath to a folder where the downloaded data will be saved.
+        dataset_id: The id of the benchmark dataset to download.
+        download: Whether to download the data if it is not present.
+
+    Returns:
+        The filepath for the stored data.
+    """
+    access_id = "10982"
+    data_path = util.download_source_empiar(path, access_id, download)
+    dataset_path = os.path.join(data_path, "data", BENCHMARK_DATASETS[dataset_id])
+    return dataset_path
+
+
+def get_benchmark_paths(
+    path: Union[os.PathLike, str], dataset_id: int, download: bool = False
+) -> Tuple[List[str], List[str], str, str, bool]:
+    """Get paths to the MitoLab benchmark data.
 
     Args:
         path: Filepath to a folder where the downloaded data will be saved.
@@ -185,9 +209,7 @@ def get_benchmark_data(
         The label data key.
         Whether this is a segmentation dataset.
     """
-    access_id = "10982"
-    data_path = util.download_source_empiar(path, access_id, download)
-    dataset_path = os.path.join(data_path, "data", BENCHMARK_DATASETS[dataset_id])
+    dataset_path = get_benchmark_data(path, dataset_id, download)
 
     # these are the 3d datasets
     if dataset_id in range(1, 7):
@@ -214,14 +236,14 @@ def get_benchmark_data(
 
 def get_mitolab_dataset(
     path: Union[os.PathLike, str],
-    split: str,
+    split: Literal['train', 'val'],
     patch_shape: Tuple[int, int] = (224, 224),
     val_fraction: float = 0.05,
     download: bool = False,
     discard_empty_images: bool = True,
     **kwargs
 ) -> Dataset:
-    """Get the dataset for the mitolab training data.
+    """Get the dataset for the MitoLab training data.
 
     Args:
         path: Filepath to a folder where the downloaded data will be saved.
@@ -237,11 +259,18 @@ def get_mitolab_dataset(
     """
     assert split in ("train", "val", None)
     assert os.path.exists(path)
-    raw_paths, label_paths = get_mitolab_data(path, split, val_fraction, download, discard_empty_images)
+
+    raw_paths, label_paths = get_mitolab_paths(path, split, val_fraction, download, discard_empty_images)
+
     return torch_em.default_segmentation_dataset(
-        raw_paths=raw_paths, raw_key=None,
-        label_paths=label_paths, label_key=None,
-        patch_shape=patch_shape, is_seg_dataset=False, ndim=2, **kwargs
+        raw_paths=raw_paths,
+        raw_key=None,
+        label_paths=label_paths,
+        label_key=None,
+        patch_shape=patch_shape,
+        is_seg_dataset=False,
+        ndim=2,
+        **kwargs
     )
 
 
@@ -250,11 +279,7 @@ def get_cem15m_dataset(path):
 
 
 def get_benchmark_dataset(
-    path,
-    dataset_id,
-    patch_shape,
-    download=False,
-    **kwargs,
+    path: Union[os.PathLike, str], dataset_id: int, patch_shape: Tuple[int, int], download: bool = False, **kwargs
 ) -> Dataset:
     """Get the dataset for one of the mitolab benchmark datasets.
 
@@ -270,12 +295,17 @@ def get_benchmark_dataset(
     """
     if dataset_id not in range(1, 8):
         raise ValueError(f"Invalid dataset id {dataset_id}, expected id in range [1, 7].")
-    raw_paths, label_paths, raw_key, label_key, is_seg_dataset = get_benchmark_data(path, dataset_id, download)
+
+    raw_paths, label_paths, raw_key, label_key, is_seg_dataset = get_benchmark_paths(path, dataset_id, download)
+
     return torch_em.default_segmentation_dataset(
-        raw_paths=raw_paths, raw_key=raw_key,
-        label_paths=label_paths, label_key=label_key,
+        raw_paths=raw_paths,
+        raw_key=raw_key,
+        label_paths=label_paths,
+        label_key=label_key,
         patch_shape=patch_shape,
-        is_seg_dataset=is_seg_dataset, **kwargs,
+        is_seg_dataset=is_seg_dataset,
+        **kwargs,
     )
 
 
@@ -294,7 +324,7 @@ def get_mitolab_loader(
     download: bool = False,
     **kwargs
 ) -> DataLoader:
-    """Get the dataloader for the mitolab training data.
+    """Get the dataloader for the MitoLab training data.
 
     Args:
         path: Filepath to a folder where the downloaded data will be saved.
@@ -309,14 +339,17 @@ def get_mitolab_loader(
     Returns:
         The PyTorch DataLoader.
     """
-    ds_kwargs, loader_kwargs = util.split_kwargs(
-        torch_em.default_segmentation_dataset, **kwargs
-    )
+    ds_kwargs, loader_kwargs = util.split_kwargs(torch_em.default_segmentation_dataset, **kwargs)
     dataset = get_mitolab_dataset(
-        path, split, patch_shape, download=download, discard_empty_images=discard_empty_images, **ds_kwargs
+        path=path,
+        split=split,
+        patch_shape=patch_shape,
+        val_fraction=val_fraction,
+        download=download,
+        discard_empty_images=discard_empty_images,
+        **ds_kwargs
     )
-    loader = torch_em.get_data_loader(dataset, batch_size, **loader_kwargs)
-    return loader
+    return torch_em.get_data_loader(dataset, batch_size, **loader_kwargs)
 
 
 def get_cem15m_loader(path):
@@ -331,7 +364,7 @@ def get_benchmark_loader(
     download: bool = False,
     **kwargs
 ) -> DataLoader:
-    """Get the dataloader for one of the mitolab benchmark datasets.
+    """Get the dataloader for one of the MitoLab benchmark datasets.
 
     Args:
         path: Filepath to a folder where the downloaded data will be saved.
@@ -344,12 +377,6 @@ def get_benchmark_loader(
     Returns:
         The DataLoader.
     """
-    ds_kwargs, loader_kwargs = util.split_kwargs(
-        torch_em.default_segmentation_dataset, **kwargs
-    )
-    dataset = get_benchmark_dataset(
-        path, dataset_id,
-        patch_shape=patch_shape, download=download, **ds_kwargs
-    )
-    loader = torch_em.get_data_loader(dataset, batch_size, **loader_kwargs)
-    return loader
+    ds_kwargs, loader_kwargs = util.split_kwargs(torch_em.default_segmentation_dataset, **kwargs)
+    dataset = get_benchmark_dataset(path, dataset_id, patch_shape=patch_shape, download=download, **ds_kwargs)
+    return torch_em.get_data_loader(dataset, batch_size, **loader_kwargs)

--- a/torch_em/data/datasets/electron_microscopy/cremi.py
+++ b/torch_em/data/datasets/electron_microscopy/cremi.py
@@ -2,6 +2,7 @@
 
 It contains three annotated volumes from the adult fruit-fly brain.
 It was held as a challenge at MICCAI 2016. For details on the dataset check out https://cremi.org/.
+Please cite the challenge if you use the dataset in your research.
 """
 # TODO add support for realigned volumes
 
@@ -15,6 +16,7 @@ from torch.utils.data import Dataset, DataLoader
 import torch_em
 
 from .. import util
+
 
 CREMI_URLS = {
     "original": {
@@ -36,12 +38,7 @@ CHECKSUMS = {
 }
 
 
-def get_cremi_data(
-    path: Union[os.PathLike, str],
-    samples: Tuple[str],
-    download: bool,
-    use_realigned: bool = False,
-) -> List[str]:
+def get_cremi_data(path: Union[os.PathLike, str], samples: Tuple[str], download: bool, use_realigned: bool = False):
     """Download the CREMI training data.
 
     Args:
@@ -49,9 +46,6 @@ def get_cremi_data(
         samples: The CREMI samples to use. The available samples are 'A', 'B', 'C'.
         download: Whether to download the data if it is not present.
         use_realigned: Use the realigned instead of the original training data.
-
-    Returns:
-        The filepaths to the training data.
     """
     if use_realigned:
         # we need to sample batches in this case
@@ -62,14 +56,33 @@ def get_cremi_data(
         checksums = CHECKSUMS["original"]
 
     os.makedirs(path, exist_ok=True)
-    data_paths = []
     for name in samples:
         url = urls[name]
         checksum = checksums[name]
         data_path = os.path.join(path, f"sample{name}.h5")
         # CREMI SSL certificates expired, so we need to disable verification
         util.download_source(data_path, url, download, checksum, verify=False)
-        data_paths.append(data_path)
+
+
+def get_cremi_paths(
+    path: Union[os.PathLike, str],
+    samples: Tuple[str, ...] = ("A", "B", "C"),
+    use_realigned: bool = False,
+    download: bool = False
+) -> List[str]:
+    """Get paths to the CREMI data.
+
+    Args:
+        path: Filepath to a folder where the downloaded data will be saved.
+        samples: The CREMI samples to use. The available samples are 'A', 'B', 'C'.
+        use_realigned: Use the realigned instead of the original training data.
+        download: Whether to download the data if it is not present.
+
+    Returns:
+        The filepaths to the training data.
+    """
+    get_cremi_data(path, samples, download, use_realigned)
+    data_paths = [os.path.join(path, f"sample{name}.h5") for name in samples]
     return data_paths
 
 
@@ -111,7 +124,7 @@ def get_cremi_dataset(
     if rois is not None:
         assert isinstance(rois, dict)
 
-    data_paths = get_cremi_data(path, samples, download, use_realigned)
+    data_paths = get_cremi_paths(path, samples, use_realigned, download)
     data_rois = [rois.get(name, np.s_[:, :, :]) for name in samples]
 
     if defect_augmentation_kwargs is not None and "artifact_source" not in defect_augmentation_kwargs:
@@ -121,14 +134,13 @@ def get_cremi_dataset(
         defect_path = os.path.join(path, "cremi_defects.h5")
         util.download_source(defect_path, url, download, checksum)
         defect_patch_shape = (1,) + tuple(patch_shape[1:])
-        artifact_source = torch_em.transform.get_artifact_source(defect_path, defect_patch_shape,
-                                                                 min_mask_fraction=0.75,
-                                                                 raw_key="defect_sections/raw",
-                                                                 mask_key="defect_sections/mask")
+        artifact_source = torch_em.transform.get_artifact_source(
+            defect_path, defect_patch_shape,
+            min_mask_fraction=0.75,
+            raw_key="defect_sections/raw",
+            mask_key="defect_sections/mask"
+        )
         defect_augmentation_kwargs.update({"artifact_source": artifact_source})
-
-    raw_key = "volumes/raw"
-    label_key = "volumes/labels/neuron_ids"
 
     # defect augmentations
     if defect_augmentation_kwargs is not None:
@@ -142,7 +154,13 @@ def get_cremi_dataset(
     )
 
     return torch_em.default_segmentation_dataset(
-        data_paths, raw_key, data_paths, label_key, patch_shape, rois=data_rois, **kwargs
+        raw_paths=data_paths,
+        raw_key="volumes/raw",
+        label_paths=data_paths,
+        label_key="volumes/labels/neuron_ids",
+        patch_shape=patch_shape,
+        rois=data_rois,
+        **kwargs
     )
 
 
@@ -182,9 +200,7 @@ def get_cremi_loader(
     Returns:
         The DataLoader.
     """
-    dataset_kwargs, loader_kwargs = util.split_kwargs(
-        torch_em.default_segmentation_dataset, **kwargs
-    )
+    dataset_kwargs, loader_kwargs = util.split_kwargs(torch_em.default_segmentation_dataset, **kwargs)
     ds = get_cremi_dataset(
         path=path,
         patch_shape=patch_shape,

--- a/torch_em/data/datasets/electron_microscopy/deepict.py
+++ b/torch_em/data/datasets/electron_microscopy/deepict.py
@@ -1,7 +1,7 @@
 """Dataset for segmentation of structures in Cryo ET.
-
 The DeePict dataset contains annotations for several structures in CryoET.
 The dataset implemented here currently only provides access to the actin annotations.
+
 The dataset is part of the publication https://doi.org/10.1038/s41592-022-01746-2.
 Plase cite it if you use this dataset in your research.
 """
@@ -9,7 +9,9 @@ Plase cite it if you use this dataset in your research.
 import os
 from glob import glob
 from shutil import rmtree
-from typing import Tuple, Union
+from typing import Tuple, Union, List
+
+from torch.utils.data import Dataset, DataLoader
 
 try:
     import mrcfile
@@ -73,7 +75,7 @@ def _process_deepict_actin(input_path, output_path):
 
 
 def get_deepict_actin_data(path: Union[os.PathLike, str], download: bool) -> str:
-    """Download the deepict actin dataset.
+    """Download the DeePict actin dataset.
 
     Args:
         path: Filepath to a folder where the downloaded data will be saved.
@@ -99,13 +101,28 @@ def get_deepict_actin_data(path: Union[os.PathLike, str], download: bool) -> str
     return dataset_path
 
 
+def get_deepict_actin_paths(path: Union[os.PathLike, str], download: bool = False) -> List[str]:
+    """Get paths to DeePict actin data.
+
+    Args:
+        path: Filepath to a folder where the downloaded data will be saved.
+        download: Whether to download the data if it is not present.
+
+    Returns:
+        The filepaths to the stored data.
+    """
+    get_deepict_actin_data(path, download)
+    data_paths = sorted(glob(os.path.join(path, "deepict_actin", "*.h5")))
+    return data_paths
+
+
 def get_deepict_actin_dataset(
     path: Union[os.PathLike, str],
     patch_shape: Tuple[int, int, int],
     label_key: str = "labels/actin",
     download: bool = False,
     **kwargs
-):
+) -> Dataset:
     """Get the dataset for actin segmentation in Cryo ET data.
 
     Args:
@@ -120,11 +137,17 @@ def get_deepict_actin_dataset(
        The segmentation dataset.
     """
     assert len(patch_shape) == 3
-    data_path = get_deepict_actin_data(path, download)
-    data_paths = sorted(glob(os.path.join(data_path, "*.h5")))
-    raw_key = "raw"
+
+    data_paths = get_deepict_actin_paths(path, download)
+
     return torch_em.default_segmentation_dataset(
-        data_paths, raw_key, data_paths, label_key, patch_shape, is_seg_dataset=True, **kwargs
+        raw_paths=data_paths,
+        raw_key="raw",
+        label_paths=data_paths,
+        label_key=label_key,
+        patch_shape=patch_shape,
+        is_seg_dataset=True,
+        **kwargs
     )
 
 
@@ -135,7 +158,7 @@ def get_deepict_actin_loader(
     label_key: str = "labels/actin",
     download: bool = False,
     **kwargs
-):
+) -> DataLoader:
     """Get the DataLoader for actin segmentation in CryoET data.
 
     Args:
@@ -150,11 +173,6 @@ def get_deepict_actin_loader(
     Returns:
         The DataLoader.
     """
-    ds_kwargs, loader_kwargs = util.split_kwargs(
-        torch_em.default_segmentation_dataset, **kwargs
-    )
-    dataset = get_deepict_actin_dataset(
-        path, patch_shape, label_key=label_key, download=download, **ds_kwargs
-    )
-    loader = torch_em.get_data_loader(dataset, batch_size, **loader_kwargs)
-    return loader
+    ds_kwargs, loader_kwargs = util.split_kwargs(torch_em.default_segmentation_dataset, **kwargs)
+    dataset = get_deepict_actin_dataset(path, patch_shape, label_key=label_key, download=download, **ds_kwargs)
+    return torch_em.get_data_loader(dataset, batch_size, **loader_kwargs)

--- a/torch_em/data/datasets/electron_microscopy/snemi.py
+++ b/torch_em/data/datasets/electron_microscopy/snemi.py
@@ -1,6 +1,6 @@
 """SNEMI is a dataset for neuron segmentation in EM.
-
 It contains an annotated volumes from the mouse brain.
+
 The data is part of the publication https://doi.org/10.1016/j.cell.2015.06.054.
 Please cite it if you use this dataset for a publication.
 """
@@ -14,6 +14,7 @@ import torch_em
 
 from .. import util
 
+
 SNEMI_URLS = {
     "train": "https://oc.embl.de/index.php/s/43iMotlXPyAB39z/download",
     "test": "https://oc.embl.de/index.php/s/aRhphk35H23De2s/download"
@@ -24,20 +25,32 @@ CHECKSUMS = {
 }
 
 
-def get_snemi_data(path: Union[os.PathLike, str], sample: str, download: bool) -> str:
+def get_snemi_data(path: Union[os.PathLike, str], sample: str, download: bool = False):
     """Download the SNEMI training data.
 
     Args:
         path: Filepath to a folder where the downloaded data will be saved.
         sample: The sample to download, either 'train' or 'test'.
         download: Whether to download the data if it is not present.
-
-    Returns:
-        The path to the downloaded data.
     """
     os.makedirs(path, exist_ok=True)
     data_path = os.path.join(path, f"snemi_{sample}.h5")
     util.download_source(data_path, SNEMI_URLS[sample], download, CHECKSUMS[sample])
+
+
+def get_snemi_paths(path: Union[os.PathLike, str], sample: str, download: bool = False) -> str:
+    """Get path to the SNEMI data.
+
+    Args:
+        path: Filepath to a folder where the downloaded data is saved.
+        sample: The sample to download, either 'train' or 'test'.
+        download: Whether to download the data if it is not present.
+
+    Returns:
+        The filepath for the stored data.
+    """
+    get_snemi_data(path, sample, download)
+    data_path = os.path.join(path, f"snemi_{sample}.h5")
     assert os.path.exists(data_path), data_path
     return data_path
 
@@ -66,16 +79,22 @@ def get_snemi_dataset(
        The segmentation dataset.
     """
     assert len(patch_shape) == 3
-    data_path = get_snemi_data(path, sample, download)
+
+    data_path = get_snemi_paths(path, sample, download)
 
     kwargs = util.update_kwargs(kwargs, "is_seg_dataset", True)
     kwargs, _ = util.add_instance_label_transform(
         kwargs, add_binary_target=False, boundaries=boundaries, offsets=offsets
     )
 
-    raw_key = "volumes/raw"
-    label_key = "volumes/labels/neuron_ids"
-    return torch_em.default_segmentation_dataset(data_path, raw_key, data_path, label_key, patch_shape, **kwargs)
+    return torch_em.default_segmentation_dataset(
+        raw_paths=data_path,
+        raw_key="volumes/raw",
+        label_paths=data_path,
+        label_key="volumes/labels/neuron_ids",
+        patch_shape=patch_shape,
+        **kwargs
+    )
 
 
 def get_snemi_loader(
@@ -103,9 +122,7 @@ def get_snemi_loader(
     Returns:
         The DataLoader.
     """
-    ds_kwargs, loader_kwargs = util.split_kwargs(
-        torch_em.default_segmentation_dataset, **kwargs
-    )
+    ds_kwargs, loader_kwargs = util.split_kwargs(torch_em.default_segmentation_dataset, **kwargs)
     ds = get_snemi_dataset(
         path=path,
         patch_shape=patch_shape,

--- a/torch_em/data/datasets/electron_microscopy/sponge_em.py
+++ b/torch_em/data/datasets/electron_microscopy/sponge_em.py
@@ -8,13 +8,14 @@ dataset in your research.
 
 import os
 from glob import glob
-from typing import Optional, Sequence, Tuple, Union
+from typing import Optional, Sequence, Tuple, Union, List
 
 from torch.utils.data import Dataset, DataLoader
 
 import torch_em
 
 from .. import util
+
 
 URL = "https://zenodo.org/record/8150818/files/sponge_em_train_data.zip?download=1"
 CHECKSUM = "f1df616cd60f81b91d7642933e9edd74dc6c486b2e546186a7c1e54c67dd32a5"
@@ -51,6 +52,28 @@ def get_sponge_em_data(path: Union[os.PathLike, str], download: bool) -> Tuple[s
     return path, n_files
 
 
+def get_sponge_em_paths(
+    path: Union[os.PathLike, str], sample_ids: Optional[Sequence[int]], download: bool = False
+) -> List[str]:
+    """Get paths to the SpongeEM data.
+
+    Args:
+        path: Filepath to a folder where the downloaded data will saved.
+        sample_ids: The sample to download, valid ids are 1, 2 and 3.
+        download: Whether to download the data if it is not present.
+
+    Returns:
+        The filepaths to the stored data.
+    """
+    data_folder, n_files = get_sponge_em_data(path, download)
+
+    if sample_ids is None:
+        sample_ids = range(1, n_files + 1)
+
+    paths = [os.path.join(data_folder, f"train_data_0{i}.h5") for i in sample_ids]
+    return paths
+
+
 def get_sponge_em_dataset(
     path: Union[os.PathLike, str],
     mode: str,
@@ -72,17 +95,18 @@ def get_sponge_em_dataset(
     Returns:
        The segmentation dataset.
     """
-
     assert mode in ("semantic", "instances")
-    data_folder, n_files = get_sponge_em_data(path, download)
 
-    if sample_ids is None:
-        sample_ids = range(1, n_files + 1)
-    paths = [os.path.join(data_folder, f"train_data_0{i}.h5") for i in sample_ids]
+    paths = get_sponge_em_paths(path, sample_ids, download)
 
-    raw_key = "volumes/raw"
-    label_key = f"volumes/labels/{mode}"
-    return torch_em.default_segmentation_dataset(paths, raw_key, paths, label_key, patch_shape, **kwargs)
+    return torch_em.default_segmentation_dataset(
+        raw_paths=paths,
+        raw_key="volumes/raw",
+        label_paths=paths,
+        label_key=f"volumes/labels/{mode}",
+        patch_shape=patch_shape,
+        **kwargs
+    )
 
 
 def get_sponge_em_loader(
@@ -108,8 +132,6 @@ def get_sponge_em_loader(
     Returns:
        The DataLoader.
     """
-    ds_kwargs, loader_kwargs = util.split_kwargs(
-        torch_em.default_segmentation_dataset, **kwargs
-    )
+    ds_kwargs, loader_kwargs = util.split_kwargs(torch_em.default_segmentation_dataset, **kwargs)
     ds = get_sponge_em_dataset(path, mode, patch_shape, sample_ids=sample_ids, download=download, **ds_kwargs)
     return torch_em.get_data_loader(ds, batch_size=batch_size, **loader_kwargs)

--- a/torch_em/data/datasets/electron_microscopy/vnc.py
+++ b/torch_em/data/datasets/electron_microscopy/vnc.py
@@ -1,6 +1,6 @@
 """The VNC dataset contains segmentation annotations for mitochondria in EM.
-
 It contains two volumes from TEM of the drosophila brain.
+
 Please cite https://doi.org/10.6084/m9.figshare.856713.v1 if you use this dataset in your publication.
 """
 
@@ -18,6 +18,7 @@ from torch.utils.data import Dataset, DataLoader
 import torch_em
 
 from .. import util
+
 
 URL = "https://github.com/unidesigner/groundtruth-drosophila-vnc/archive/refs/heads/master.zip"
 CHECKSUM = "f7bd0db03c86b64440a16b60360ad60c0a4411f89e2c021c7ee2c8d6af3d7e86"
@@ -71,6 +72,21 @@ def get_vnc_data(path: Union[os.PathLike, str], download: bool) -> str:
     return path
 
 
+def get_vnc_mito_paths(path: Union[os.PathLike, str], download: bool = False) -> str:
+    """Get path to the VNC data.
+
+    Args:
+        path: Filepath to a folder where the downloaded data is saved.
+        download: Whether to download the data if it is not present.
+
+    Returns:
+        The filepath to the stored data.
+    """
+    get_vnc_data(path, download)
+    data_path = os.path.join(path, "vnc_train.h5")
+    return data_path
+
+
 def get_vnc_mito_dataset(
     path: Union[os.PathLike, str],
     patch_shape: Tuple[int, int, int],
@@ -94,16 +110,20 @@ def get_vnc_mito_dataset(
     Returns:
        The segmentation dataset.
     """
-    get_vnc_data(path, download)
-    data_path = os.path.join(path, "vnc_train.h5")
+    data_path = get_vnc_mito_paths(path, download)
 
     kwargs, _ = util.add_instance_label_transform(
         kwargs, add_binary_target=True, boundaries=boundaries, offsets=offsets, binary=binary,
     )
 
-    raw_key = "raw"
-    label_key = "labels/mitochondria"
-    return torch_em.default_segmentation_dataset(data_path, raw_key, data_path, label_key, patch_shape, **kwargs)
+    return torch_em.default_segmentation_dataset(
+        raw_paths=data_path,
+        raw_key="raw",
+        label_paths=data_path,
+        label_key="labels/mitochondria",
+        patch_shape=patch_shape,
+        **kwargs
+    )
 
 
 def get_vnc_mito_loader(
@@ -131,9 +151,7 @@ def get_vnc_mito_loader(
     Returns:
        The DataLoader.
     """
-    ds_kwargs, loader_kwargs = util.split_kwargs(
-        torch_em.default_segmentation_dataset, **kwargs
-    )
+    ds_kwargs, loader_kwargs = util.split_kwargs(torch_em.default_segmentation_dataset, **kwargs)
     ds = get_vnc_mito_dataset(
         path, patch_shape, download=download, offsets=offsets, boundaries=boundaries, binary=binary, **ds_kwargs
     )

--- a/torch_em/data/datasets/light_microscopy/cellseg_3d.py
+++ b/torch_em/data/datasets/light_microscopy/cellseg_3d.py
@@ -6,7 +6,7 @@ Please cite it if you use this dataset in your research.
 
 import os
 from glob import glob
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple, Union, List
 
 from torch.utils.data import Dataset, DataLoader
 
@@ -14,11 +14,12 @@ import torch_em
 
 from .. import util
 
+
 URL = "https://zenodo.org/records/11095111/files/DATASET_WITH_GT.zip?download=1"
 CHECKSUM = "6d8e8d778e479000161fdfea70201a6ded95b3958a703f69def63e69bbddf9d6"
 
 
-def get_cellseg_3d_data(path: Union[os.PathLike, str], download: bool) -> str:
+def get_cellseg_3d_data(path: Union[os.PathLike, str], download: bool = False) -> str:
     """Download the CellSeg3d training data.
 
     Args:
@@ -43,6 +44,26 @@ def get_cellseg_3d_data(path: Union[os.PathLike, str], download: bool) -> str:
     return data_path
 
 
+def get_cellseg_3d_paths(path: Union[os.PathLike, str], download: bool = False) -> Tuple[List[str], List[str]]:
+    """Get paths to the CellSeg3d data.
+
+    Args:
+        path: Filepath to a folder where the downloaded data will be saved.
+        download: Whether to download the data if it is not present.
+
+    Returns:
+        List of filepaths for the image data.
+        List of filepaths for the label data.
+    """
+    data_root = get_cellseg_3d_data(path, download)
+
+    raw_paths = sorted(glob(os.path.join(data_root, "*.tif")))
+    label_paths = sorted(glob(os.path.join(data_root, "labels", "*.tif")))
+    assert len(raw_paths) == len(label_paths)
+
+    return raw_paths, label_paths
+
+
 def get_cellseg_3d_dataset(
     path: Union[os.PathLike, str],
     patch_shape: Tuple[int, int],
@@ -62,20 +83,20 @@ def get_cellseg_3d_dataset(
     Returns:
        The segmentation dataset.
     """
-    data_root = get_cellseg_3d_data(path, download)
+    raw_paths, label_paths = get_cellseg_3d_paths(path, download)
 
-    raw_paths = sorted(glob(os.path.join(data_root, "*.tif")))
-    label_paths = sorted(glob(os.path.join(data_root, "labels", "*.tif")))
-    assert len(raw_paths) == len(label_paths)
     if sample_ids is not None:
         assert all(sid < len(raw_paths) for sid in sample_ids)
         raw_paths = [raw_paths[i] for i in sample_ids]
         label_paths = [label_paths[i] for i in sample_ids]
 
-    raw_key, label_key = None, None
-
     return torch_em.default_segmentation_dataset(
-        raw_paths, raw_key, label_paths, label_key, patch_shape, **kwargs
+        raw_paths=raw_paths,
+        raw_key=None,
+        label_paths=label_paths,
+        label_key=None,
+        patch_shape=patch_shape,
+        **kwargs
     )
 
 
@@ -87,7 +108,7 @@ def get_cellseg_3d_loader(
     download: bool = False,
     **kwargs
 ) -> DataLoader:
-    """Get the CellSeg3d dataloder for segmenting nuclei in 3d fluorescence microscopy.
+    """Get the CellSeg3d dataloader for segmenting nuclei in 3d fluorescence microscopy.
 
     Args:
         path: Filepath to a folder where the downloaded data will be saved.
@@ -101,8 +122,5 @@ def get_cellseg_3d_loader(
         The DataLoader.
     """
     ds_kwargs, loader_kwargs = util.split_kwargs(torch_em.default_segmentation_dataset, **kwargs)
-    dataset = get_cellseg_3d_dataset(
-        path, patch_shape, sample_ids=sample_ids, download=download, **ds_kwargs,
-    )
-    loader = torch_em.get_data_loader(dataset, batch_size=batch_size, **loader_kwargs)
-    return loader
+    dataset = get_cellseg_3d_dataset(path, patch_shape, sample_ids=sample_ids, download=download, **ds_kwargs)
+    return torch_em.get_data_loader(dataset, batch_size=batch_size, **loader_kwargs)

--- a/torch_em/data/datasets/light_microscopy/covid_if.py
+++ b/torch_em/data/datasets/light_microscopy/covid_if.py
@@ -15,12 +15,13 @@ import torch_em
 
 from .. import util
 
+
 COVID_IF_URL = "https://zenodo.org/record/5092850/files/covid-if-groundtruth.zip?download=1"
 CHECKSUM = "d9cd6c85a19b802c771fb4ff928894b19a8fab0e0af269c49235fdac3f7a60e1"
 
 
-def get_covid_if_data(path: Union[os.PathLike, str], download: bool) -> str:
-    """Download the CovidIF training data.
+def get_covid_if_data(path: Union[os.PathLike, str], download: bool = False) -> str:
+    """Download the Covid-IF training data.
 
     Args:
         path: Filepath to a folder where the downloaded data will be saved.
@@ -43,6 +44,36 @@ def get_covid_if_data(path: Union[os.PathLike, str], download: bool) -> str:
     return path
 
 
+def get_covid_if_paths(
+    path: Union[os.PathLike, str],
+    sample_range: Optional[Tuple[int, int]] = None,
+    download: bool = False
+) -> List[str]:
+    """Get paths to the Covid-IF data.
+
+    Args:
+        path: Filepath to a folder where the downloaded data will be saved.
+        sample_range: Id range of samples to load from the training dataset.
+        download: Whether to download the data if it is not present.
+
+    Returns:
+        List of filepaths to the stored data.
+    """
+    get_covid_if_data(path, download)
+
+    file_paths = sorted(glob(os.path.join(path, "*.h5")))
+    if sample_range is not None:
+        start, stop = sample_range
+        if start is None:
+            start = 0
+        if stop is None:
+            stop = len(file_paths)
+        file_paths = [os.path.join(path, f"gt_image_{idx:03}.h5") for idx in range(start, stop)]
+        assert all(os.path.exists(fp) for fp in file_paths), f"Invalid sample range {sample_range}"
+
+    return file_paths
+
+
 def get_covid_if_dataset(
     path: Union[os.PathLike, str],
     patch_shape: Tuple[int, int],
@@ -54,7 +85,7 @@ def get_covid_if_dataset(
     binary: bool = False,
     **kwargs
 ) -> Dataset:
-    """Get the CovidIF dataset for segmenting nuclei or cells in immunofluorescence microscopy.
+    """Get the Covid-IF dataset for segmenting nuclei or cells in immunofluorescence microscopy.
 
     Args:
         path: Filepath to a folder where the downloaded data will be saved.
@@ -73,7 +104,6 @@ def get_covid_if_dataset(
     available_targets = ("cells", "nuclei")
     # TODO also support infected_cells
     # available_targets = ("cells", "nuclei", "infected_cells")
-    assert target in available_targets, f"{target} not found in {available_targets}"
 
     if target == "cells":
         raw_key = "raw/serum_IgG/s0"
@@ -81,18 +111,10 @@ def get_covid_if_dataset(
     elif target == "nuclei":
         raw_key = "raw/nuclei/s0"
         label_key = "labels/nuclei/s0"
+    else:
+        raise ValueError(f"{target} not found in {available_targets}")
 
-    get_covid_if_data(path, download)
-
-    file_paths = sorted(glob(os.path.join(path, "*.h5")))
-    if sample_range is not None:
-        start, stop = sample_range
-        if start is None:
-            start = 0
-        if stop is None:
-            stop = len(file_paths)
-        file_paths = [os.path.join(path, f"gt_image_{idx:03}.h5") for idx in range(start, stop)]
-        assert all(os.path.exists(fp) for fp in file_paths), f"Invalid sample range {sample_range}"
+    file_paths = get_covid_if_paths(path, sample_range, download)
 
     kwargs, _ = util.add_instance_label_transform(
         kwargs, add_binary_target=True, binary=binary, boundaries=boundaries, offsets=offsets
@@ -100,7 +122,12 @@ def get_covid_if_dataset(
     kwargs = util.update_kwargs(kwargs, "ndim", 2)
 
     return torch_em.default_segmentation_dataset(
-        file_paths, raw_key, file_paths, label_key, patch_shape, **kwargs
+        raw_paths=file_paths,
+        raw_key=raw_key,
+        label_paths=file_paths,
+        label_key=label_key,
+        patch_shape=patch_shape,
+        **kwargs
     )
 
 
@@ -116,7 +143,7 @@ def get_covid_if_loader(
     binary: bool = False,
     **kwargs
 ) -> DataLoader:
-    """Get the CovidIF dataloder for segmenting nuclei or cells in immunofluorescence microscopy.
+    """Get the Covid-IF dataloder for segmenting nuclei or cells in immunofluorescence microscopy.
 
     Args:
         path: Filepath to a folder where the downloaded data will be saved.
@@ -138,5 +165,4 @@ def get_covid_if_loader(
         path, patch_shape, sample_range=sample_range, target=target, download=download,
         offsets=offsets, boundaries=boundaries, binary=binary, **ds_kwargs,
     )
-    loader = torch_em.get_data_loader(dataset, batch_size=batch_size, **loader_kwargs)
-    return loader
+    return torch_em.get_data_loader(dataset, batch_size=batch_size, **loader_kwargs)

--- a/torch_em/data/datasets/light_microscopy/ctc.py
+++ b/torch_em/data/datasets/light_microscopy/ctc.py
@@ -1,6 +1,6 @@
 """The Cell Tracking Challenge contains annotated data for cell segmentation and tracking.
+We currently provide the 2d datasets with segmentation annotations.
 
-We currently cprovide the 2d datasets with segmentation annotations.
 If you use this data in your research please cite https://doi.org/10.1038/nmeth.4473.
 """
 
@@ -55,20 +55,17 @@ def _get_ctc_url_and_checksum(dataset_name, split):
     return url, checksum
 
 
-def get_ctc_data(
-    path: Union[os.PathLike, str],
-    dataset_name: str,
-    download: bool,
-    split: str
+def get_ctc_segmentation_data(
+    path: Union[os.PathLike, str], dataset_name: str, split: str, download: bool = False,
 ) -> str:
-    f"""Download training data from the cell tracking challenge.
+    f"""Download training data from the Cell Tracking Challenge.
 
     Args:
         path: Filepath to a folder where the downloaded data will be saved.
         dataset_name: Name of the dataset to be downloaded. The available datasets are:
             {', '.join(CTC_CHECKSUMS['train'].keys())}
-        download: Whether to download the data if it is not present.
         split: The split to download. Either 'train' or 'test'.
+        download: Whether to download the data if it is not present.
 
     Returns:
         The filepath to the training data.
@@ -123,6 +120,40 @@ def _require_gt_images(data_path, vol_ids):
     return image_paths, label_paths
 
 
+def get_ctc_segmentation_paths(
+    path: Union[os.PathLike, str],
+    dataset_name: str,
+    split: str = "train",
+    vol_id: Optional[int] = None,
+    download: bool = False,
+) -> Tuple[str, str]:
+    f"""Get paths to the Cell Tracking Challenge data.
+
+    Args:
+        path: Filepath to a folder where the downloaded data will be saved.
+        dataset_name: Name of the dataset to be downloaded. The available datasets are:
+            {', '.join(CTC_CHECKSUMS['train'].keys())}
+        split: The split to download. Currently only supports 'train'.
+        vol_id: The train id to load.
+        download: Whether to download the data if it is not present.
+
+    Returns:
+        Filepath to the folder where image data is stored.
+        Filepath to the folder where label data is stored.
+    """
+    data_path = get_ctc_segmentation_data(path, dataset_name, download, split)
+
+    if vol_id is None:
+        vol_ids = glob(os.path.join(data_path, "*_GT"))
+        vol_ids = [os.path.basename(vol_id) for vol_id in vol_ids]
+        vol_ids = [vol_id.rstrip("_GT") for vol_id in vol_ids]
+    else:
+        vol_ids = vol_id
+
+    image_path, label_path = _require_gt_images(data_path, vol_ids)
+    return image_path, label_path
+
+
 def get_ctc_segmentation_dataset(
     path: Union[os.PathLike, str],
     dataset_name: str,
@@ -149,20 +180,18 @@ def get_ctc_segmentation_dataset(
     """
     assert split in ["train"]
 
-    data_path = get_ctc_data(path, dataset_name, download, split)
-
-    if vol_id is None:
-        vol_ids = glob(os.path.join(data_path, "*_GT"))
-        vol_ids = [os.path.basename(vol_id) for vol_id in vol_ids]
-        vol_ids = [vol_id.rstrip("_GT") for vol_id in vol_ids]
-    else:
-        vol_ids = vol_id
-
-    image_path, label_path = _require_gt_images(data_path, vol_ids)
+    image_path, label_path = get_ctc_segmentation_paths(path, dataset_name, split, vol_id, download)
 
     kwargs = util.update_kwargs(kwargs, "ndim", 2)
+
     return torch_em.default_segmentation_dataset(
-        image_path, "*.tif", label_path, "*.tif", patch_shape, is_seg_dataset=True, **kwargs
+        raw_paths=image_path,
+        raw_key="*.tif",
+        label_paths=label_path,
+        label_key="*.tif",
+        patch_shape=patch_shape,
+        is_seg_dataset=True,
+        **kwargs
     )
 
 
@@ -176,7 +205,7 @@ def get_ctc_segmentation_loader(
     download: bool = False,
     **kwargs,
 ) -> DataLoader:
-    """Get the CTC dataloader for cell segmentation.
+    f"""Get the CTC dataloader for cell segmentation.
 
     Args:
         path: Filepath to a folder where the downloaded data will be saved.
@@ -192,12 +221,8 @@ def get_ctc_segmentation_loader(
     Returns:
        The DataLoader.
     """
-    ds_kwargs, loader_kwargs = util.split_kwargs(
-        torch_em.default_segmentation_dataset, **kwargs
-    )
+    ds_kwargs, loader_kwargs = util.split_kwargs(torch_em.default_segmentation_dataset, **kwargs)
     dataset = get_ctc_segmentation_dataset(
         path, dataset_name, patch_shape, split=split, vol_id=vol_id, download=download, **ds_kwargs,
     )
-
-    loader = torch_em.get_data_loader(dataset, batch_size, **loader_kwargs)
-    return loader
+    return torch_em.get_data_loader(dataset, batch_size, **loader_kwargs)

--- a/torch_em/data/datasets/light_microscopy/deepbacs.py
+++ b/torch_em/data/datasets/light_microscopy/deepbacs.py
@@ -100,7 +100,7 @@ def get_deepbacs_data(path: Union[os.PathLike, str], bac_type: str, download: bo
     return data_folder
 
 
-def _get_paths(path, bac_type, split):
+def _get_deepbacs_paths(path, bac_type, split):
     # the bacteria types other than mixed are a bit more complicated so we don't have the dataloaders for them yet
     # mixed is the combination of all other types
     if split == "train":
@@ -139,7 +139,7 @@ def get_deepbacs_dataset(
     """
     assert split in ("train", "val", "test")
     get_deepbacs_data(path, bac_type, download)
-    image_folder, label_folder = _get_paths(path, bac_type, split)
+    image_folder, label_folder = _get_deepbacs_paths(path, bac_type, split)
     dataset = torch_em.default_segmentation_dataset(
         image_folder, "*.tif", label_folder, "*.tif", patch_shape=patch_shape, **kwargs
     )

--- a/torch_em/data/datasets/light_microscopy/dynamicnuclearnet.py
+++ b/torch_em/data/datasets/light_microscopy/dynamicnuclearnet.py
@@ -11,7 +11,7 @@ and download it yourself.
 import os
 from tqdm import tqdm
 from glob import glob
-from typing import Tuple, Union
+from typing import Tuple, Union, List
 
 import numpy as np
 import pandas as pd
@@ -94,6 +94,25 @@ def get_dynamicnuclearnet_data(
     return split_folder
 
 
+def get_dynamicnuclearnet_paths(path: Union[os.PathLike, str], split: str, download: bool = False) -> List[str]:
+    """Get paths to the DynamicNuclearNet data.
+
+    Args:
+        path: Filepath to a folder where the downloaded data will be saved.
+        split: The split to use for the dataset. Either 'train', 'val' or 'test'.
+        download: Whether to download the data if it is not present.
+
+    Returns:
+        List of filepaths for the stored data.
+    """
+    split_folder = get_dynamicnuclearnet_data(path, split, download)
+    assert os.path.exists(split_folder)
+    data_paths = glob(os.path.join(split_folder, "*.zarr"))
+    assert len(data_paths) > 0
+
+    return data_paths
+
+
 def get_dynamicnuclearnet_dataset(
     path: Union[os.PathLike, str],
     split: str,
@@ -113,15 +132,17 @@ def get_dynamicnuclearnet_dataset(
     Returns:
        The segmentation dataset.
     """
-    split_folder = get_dynamicnuclearnet_data(path, split, download)
-    assert os.path.exists(split_folder)
-    data_path = glob(os.path.join(split_folder, "*.zarr"))
-    assert len(data_path) > 0
-
-    raw_key, label_key = "raw", "labels"
+    data_paths = get_dynamicnuclearnet_paths(path, split, download)
 
     return torch_em.default_segmentation_dataset(
-        data_path, raw_key, data_path, label_key, patch_shape, is_seg_dataset=True, ndim=2, **kwargs
+        raw_paths=data_paths,
+        raw_key="raw",
+        label_paths=data_paths,
+        label_key="labels",
+        patch_shape=patch_shape,
+        is_seg_dataset=True,
+        ndim=2,
+        **kwargs
     )
 
 
@@ -148,5 +169,4 @@ def get_dynamicnuclearnet_loader(
     """
     ds_kwargs, loader_kwargs = util.split_kwargs(torch_em.default_segmentation_dataset, **kwargs)
     dataset = get_dynamicnuclearnet_dataset(path, split, patch_shape, download, **ds_kwargs)
-    loader = torch_em.get_data_loader(dataset, batch_size, **loader_kwargs)
-    return loader
+    return torch_em.get_data_loader(dataset, batch_size, **loader_kwargs)

--- a/torch_em/data/datasets/light_microscopy/livecell.py
+++ b/torch_em/data/datasets/light_microscopy/livecell.py
@@ -14,12 +14,13 @@ from typing import List, Optional, Sequence, Tuple, Union
 import numpy as np
 import imageio.v3 as imageio
 
-import torch.utils.data
+import torch
 from torch.utils.data import Dataset, DataLoader
 
 import torch_em
 
 from .. import util
+from ... import ImageCollectionDataset
 
 try:
     from pycocotools.coco import COCO
@@ -37,20 +38,6 @@ URLS = {
 }
 # TODO
 CHECKSUM = None
-
-
-def _download_livecell_images(path, download):
-    os.makedirs(path, exist_ok=True)
-    image_path = os.path.join(path, "images")
-
-    if os.path.exists(image_path):
-        return
-
-    url = URLS["images"]
-    checksum = CHECKSUM
-    zip_path = os.path.join(path, "livecell.zip")
-    util.download_source(zip_path, url, download, checksum)
-    util.unzip(zip_path, path, True)
 
 
 # TODO use download flag
@@ -156,19 +143,34 @@ def _download_livecell_annotations(path, split, download, cell_types, label_path
     return _create_segmentations_from_annotations(annotation_file, image_folder, seg_folder, cell_types)
 
 
-def _get_livecell_paths(path, split, download=False, cell_types=None, label_path=None):
-    image_paths, seg_paths = _download_livecell_annotations(path, split, download, cell_types, label_path)
-    return image_paths, seg_paths
+def get_livecell_data(path: Union[os.PathLike], download: bool = False):
+    """Download the LIVECell dataset.
+
+    Args:
+        path: Filepath to a folder where the downloaded data will be saved.
+        download: Whether to download the data if it is not present.
+    """
+    os.makedirs(path, exist_ok=True)
+    image_path = os.path.join(path, "images")
+
+    if os.path.exists(image_path):
+        return
+
+    url = URLS["images"]
+    checksum = CHECKSUM
+    zip_path = os.path.join(path, "livecell.zip")
+    util.download_source(zip_path, url, download, checksum)
+    util.unzip(zip_path, path, True)
 
 
-def get_livecell_data(
+def get_livecell_paths(
     path: Union[os.PathLike, str],
     split: str,
     download: bool,
     cell_types: Optional[Sequence[str]] = None,
     label_path: Optional[Union[os.PathLike, str]] = None
 ) -> Tuple[List[str], List[str]]:
-    """Download the LIVECell dataset.
+    """Get paths to the LIVECell data.
 
     Args:
         path: Filepath to a folder where the downloaded data will be saved.
@@ -178,11 +180,11 @@ def get_livecell_data(
         label_path: Optional path for loading the label data.
 
     Returns:
-        The paths to the image data.
-        The paths to the label data.
+        List of filepaths for the image data.
+        List of filepaths for the label data.
     """
-    _download_livecell_images(path, download)
-    image_paths, seg_paths = _get_livecell_paths(path, split, download, cell_types, label_path)
+    get_livecell_data(path, download)
+    image_paths, seg_paths = _download_livecell_annotations(path, split, download, cell_types, label_path)
     return image_paths, seg_paths
 
 
@@ -222,18 +224,20 @@ def get_livecell_dataset(
         assert isinstance(cell_types, (list, tuple)), \
             f"cell_types must be passed as a list or tuple instead of {cell_types}"
 
-    image_paths, seg_paths = get_livecell_data(path, split, download, cell_types, label_path)
+    image_paths, seg_paths = get_livecell_paths(path, split, download, cell_types, label_path)
 
     kwargs = util.ensure_transforms(ndim=2, **kwargs)
     kwargs, label_dtype = util.add_instance_label_transform(
-        kwargs, add_binary_target=True, label_dtype=label_dtype,
-        offsets=offsets, boundaries=boundaries, binary=binary
+        kwargs, add_binary_target=True, label_dtype=label_dtype, offsets=offsets, boundaries=boundaries, binary=binary
     )
 
-    dataset = torch_em.data.ImageCollectionDataset(
-        image_paths, seg_paths, patch_shape=patch_shape, label_dtype=label_dtype, **kwargs
+    return ImageCollectionDataset(
+        raw_image_paths=image_paths,
+        label_image_paths=seg_paths,
+        patch_shape=patch_shape,
+        label_dtype=label_dtype,
+        **kwargs
     )
-    return dataset
 
 
 def get_livecell_loader(
@@ -274,5 +278,4 @@ def get_livecell_loader(
         path, split, patch_shape, download=download, offsets=offsets, boundaries=boundaries, binary=binary,
         cell_types=cell_types, label_path=label_path, label_dtype=label_dtype, **ds_kwargs
     )
-    loader = torch_em.get_data_loader(dataset, batch_size, **loader_kwargs)
-    return loader
+    return torch_em.get_data_loader(dataset, batch_size, **loader_kwargs)

--- a/torch_em/data/datasets/light_microscopy/livecell.py
+++ b/torch_em/data/datasets/light_microscopy/livecell.py
@@ -166,7 +166,7 @@ def get_livecell_data(path: Union[os.PathLike], download: bool = False):
 def get_livecell_paths(
     path: Union[os.PathLike, str],
     split: str,
-    download: bool,
+    download: bool = False,
     cell_types: Optional[Sequence[str]] = None,
     label_path: Optional[Union[os.PathLike, str]] = None
 ) -> Tuple[List[str], List[str]]:

--- a/torch_em/data/datasets/light_microscopy/livecell.py
+++ b/torch_em/data/datasets/light_microscopy/livecell.py
@@ -156,6 +156,11 @@ def _download_livecell_annotations(path, split, download, cell_types, label_path
     return _create_segmentations_from_annotations(annotation_file, image_folder, seg_folder, cell_types)
 
 
+def _get_livecell_paths(path, split, download=False, cell_types=None, label_path=None):
+    image_paths, seg_paths = _download_livecell_annotations(path, split, download, cell_types, label_path)
+    return image_paths, seg_paths
+
+
 def get_livecell_data(
     path: Union[os.PathLike, str],
     split: str,
@@ -177,7 +182,7 @@ def get_livecell_data(
         The paths to the label data.
     """
     _download_livecell_images(path, download)
-    image_paths, seg_paths = _download_livecell_annotations(path, split, download, cell_types, label_path)
+    image_paths, seg_paths = _get_livecell_paths(path, split, download, cell_types, label_path)
     return image_paths, seg_paths
 
 

--- a/torch_em/data/datasets/light_microscopy/mouse_embryo.py
+++ b/torch_em/data/datasets/light_microscopy/mouse_embryo.py
@@ -15,6 +15,7 @@ import torch_em
 
 from .. import util
 
+
 URL = "https://zenodo.org/record/6546550/files/MouseEmbryos.zip?download=1"
 CHECKSUM = "bf24df25e5f919489ce9e674876ff27e06af84445c48cf2900f1ab590a042622"
 
@@ -38,6 +39,29 @@ def get_mouse_embryo_data(path: Union[os.PathLike, str], download: bool) -> str:
     # Remove empty volume.
     os.remove(os.path.join(path, "Membrane", "train", "fused_paral_stack0_chan2_tp00073_raw_crop_bg_noise.h5"))
     return path
+
+
+def get_mouse_embryo_paths(path: Union[os.PathLike, str], name: str, split: str, download: bool = False) -> List[str]:
+    """Get paths to the Mouse Embryo data.
+
+    Args:
+        path: Filepath to a folder where the downloaded data will be saved.
+        name: The name of the segmentation task. Either 'membrane' or 'nuclei'.
+        split: The split to use for the dataset. Either 'train' or 'val'.
+        download: Whether to download the data if it is not present.
+
+    Returns:
+        List of filepaths for the stored data.
+    """
+    get_mouse_embryo_data(path, download)
+
+    # the naming of the data is inconsistent: membrane has val, nuclei has test;
+    # we treat nuclei:test as val
+    split_ = "test" if name == "nuclei" and split == "val" else split
+    file_paths = glob(os.path.join(path, name.capitalize(), split_, "*.h5"))
+    file_paths.sort()
+
+    return file_paths
 
 
 def get_mouse_embryo_dataset(
@@ -70,21 +94,26 @@ def get_mouse_embryo_dataset(
     assert name in ("membrane", "nuclei")
     assert split in ("train", "val")
     assert len(patch_shape) == 3
-    get_mouse_embryo_data(path, download)
 
-    # the naming of the data is inconsistent: membrane has val, nuclei has test;
-    # we treat nuclei:test as val
-    split_ = "test" if name == "nuclei" and split == "val" else split
-    file_paths = glob(os.path.join(path, name.capitalize(), split_, "*.h5"))
-    file_paths.sort()
+    file_paths = get_mouse_embryo_paths(path, name, split, download)
 
     kwargs, _ = util.add_instance_label_transform(
-        kwargs, add_binary_target=binary, binary=binary, boundaries=boundaries,
-        offsets=offsets, binary_is_exclusive=False
+        kwargs,
+        add_binary_target=binary,
+        binary=binary,
+        boundaries=boundaries,
+        offsets=offsets,
+        binary_is_exclusive=False
     )
 
-    raw_key, label_key = "raw", "label"
-    return torch_em.default_segmentation_dataset(file_paths, raw_key, file_paths, label_key, patch_shape, **kwargs)
+    return torch_em.default_segmentation_dataset(
+        raw_paths=file_paths,
+        raw_key="raw",
+        label_paths=file_paths,
+        label_key="label",
+        patch_shape=patch_shape,
+        **kwargs
+    )
 
 
 def get_mouse_embryo_loader(
@@ -116,13 +145,9 @@ def get_mouse_embryo_loader(
     Returns:
         The DataLoader.
     """
-    ds_kwargs, loader_kwargs = util.split_kwargs(
-        torch_em.default_segmentation_dataset, **kwargs
-    )
+    ds_kwargs, loader_kwargs = util.split_kwargs(torch_em.default_segmentation_dataset, **kwargs)
     dataset = get_mouse_embryo_dataset(
-        path, name, split, patch_shape,
-        download=download, offsets=offsets, boundaries=boundaries, binary=binary,
-        **ds_kwargs
+        path, name, split, patch_shape, download=download, offsets=offsets,
+        boundaries=boundaries, binary=binary, **ds_kwargs
     )
-    loader = torch_em.get_data_loader(dataset, batch_size, **loader_kwargs)
-    return loader
+    return torch_em.get_data_loader(dataset, batch_size, **loader_kwargs)

--- a/torch_em/data/datasets/light_microscopy/neurips_cell_seg.py
+++ b/torch_em/data/datasets/light_microscopy/neurips_cell_seg.py
@@ -10,7 +10,7 @@ Please cite it if you use the dataset in your research.
 
 import os
 from glob import glob
-from typing import Union, Tuple, Any, Optional
+from typing import Union, Tuple, Any, Optional, List
 
 import numpy as np
 
@@ -87,7 +87,21 @@ def get_neurips_cellseg_data(root: Union[os.PathLike, str], split: str, download
     return target_dir
 
 
-def _get_image_and_label_paths(root, split, download):
+def get_neurips_cellseg_paths(
+    root: Union[os.PathLike, str], split: str, download: bool = False
+) -> Tuple[List[str], List[str]]:
+    f"""Get paths to NeurIPS CellSeg Challenge data.
+
+    Args:
+        root: Filepath to a folder where the downloaded data will be saved.
+        split: The data split to download. Available splits are:
+            {', '.join(URL.keys())}
+        download: Whether to download the data if it is not present.
+
+    Returns:
+        List of filepaths for the image data.
+        List of filepaths for the label data.
+    """
     path = get_neurips_cellseg_data(root, split, download)
 
     image_folder = os.path.join(path, "images")
@@ -138,15 +152,16 @@ def get_neurips_cellseg_supervised_dataset(
         The segmentation dataset.
     """
     assert split in ("train", "val", "test"), split
-    image_paths, label_paths = _get_image_and_label_paths(root, split, download)
+    image_paths, label_paths = get_neurips_cellseg_paths(root, split, download)
 
     if raw_transform is None:
         trafo = to_rgb if make_rgb else None
         raw_transform = torch_em.transform.get_raw_transform(augmentation2=trafo)
+
     if transform is None:
         transform = torch_em.transform.get_augmentations(ndim=2)
 
-    ds = ImageCollectionDataset(
+    return ImageCollectionDataset(
         raw_image_paths=image_paths,
         label_image_paths=label_paths,
         patch_shape=patch_shape,
@@ -158,7 +173,6 @@ def get_neurips_cellseg_supervised_dataset(
         n_samples=n_samples,
         sampler=sampler
     )
-    return ds
 
 
 def get_neurips_cellseg_supervised_loader(

--- a/torch_em/data/datasets/light_microscopy/omnipose.py
+++ b/torch_em/data/datasets/light_microscopy/omnipose.py
@@ -28,10 +28,7 @@ CHECKSUM = None
 DATA_CHOICES = ["bact_fluor", "bact_phase", "worm", "worm_high_res"]
 
 
-def get_omnipose_data(
-    path: Union[os.PathLike, str],
-    download: bool = False,
-):
+def get_omnipose_data(path: Union[os.PathLike, str], download: bool = False) -> str:
     """Download the OmniPose dataset.
 
     Args:
@@ -39,7 +36,7 @@ def get_omnipose_data(
         download: Whether to download the data if it is not present.
 
     Return:
-        The filepath to the data.
+        The filepath where the data is downloaded.
     """
     os.makedirs(path, exist_ok=True)
 
@@ -54,7 +51,25 @@ def get_omnipose_data(
     return data_dir
 
 
-def _get_omnipose_paths(path, split, data_choice, download):
+def get_omnipose_paths(
+    path: Union[os.PathLike, str],
+    split: str,
+    data_choice: Optional[Union[str, List[str]]] = None,
+    download: bool = False
+) -> Tuple[List[str], List[str]]:
+    """Get paths to the OmniPose data.
+
+    Args:
+        path: Filepath to a folder where the downloaded data will be saved.
+        split: The data split to use. Either 'train' or 'test'.
+        data_choice: The choice of specific data.
+            Either 'bact_fluor', 'bact_phase', 'worm' or 'worm_high_res'.
+        download: Whether to download the data if it is not present.
+
+    Returns:
+        List of filepaths for the image data.
+        List of filepaths for the label data.
+    """
     data_dir = get_omnipose_data(path=path, download=download)
 
     if split not in ["train", "test"]:
@@ -114,9 +129,9 @@ def get_omnipose_dataset(
     Returns:
         The segmentation dataset.
     """
-    image_paths, gt_paths = _get_omnipose_paths(path, split, data_choice, download)
-    print(len(image_paths), len(gt_paths))
-    dataset = torch_em.default_segmentation_dataset(
+    image_paths, gt_paths = get_omnipose_paths(path, split, data_choice, download)
+
+    return torch_em.default_segmentation_dataset(
         raw_paths=image_paths,
         raw_key=None,
         label_paths=gt_paths,
@@ -125,7 +140,6 @@ def get_omnipose_dataset(
         patch_shape=patch_shape,
         **kwargs
     )
-    return dataset
 
 
 def get_omnipose_loader(
@@ -156,5 +170,4 @@ def get_omnipose_loader(
     dataset = get_omnipose_dataset(
         path=path, patch_shape=patch_shape, split=split, data_choice=data_choice, download=download, **ds_kwargs
     )
-    loader = torch_em.get_data_loader(dataset=dataset, batch_size=batch_size, **loader_kwargs)
-    return loader
+    return torch_em.get_data_loader(dataset=dataset, batch_size=batch_size, **loader_kwargs)

--- a/torch_em/data/datasets/light_microscopy/organoidnet.py
+++ b/torch_em/data/datasets/light_microscopy/organoidnet.py
@@ -1,8 +1,17 @@
+"""The OrganoIDNet dataset contains annotations of panceratic organoids.
+
+This dataset is from the publication https://doi.org/10.1007/s13402-024-00958-2.
+Please cite it if you use this dataset for a publication.
+"""
+
+
 import os
 import shutil
 import zipfile
 from glob import glob
-from typing import Tuple, Union
+from typing import Tuple, Union, List
+
+from torch.utils.data import Dataset, DataLoader
 
 import torch_em
 
@@ -13,7 +22,17 @@ URL = "https://zenodo.org/records/10643410/files/OrganoIDNetData.zip?download=1"
 CHECKSUM = "3cd9239bf74bda096ecb5b7bdb95f800c7fa30b9937f9aba6ddf98d754cbfa3d"
 
 
-def get_organoidnet_data(path, split, download):
+def get_organoidnet_data(path: Union[os.PathLike, str], split: str, download: bool = False) -> str:
+    """Download the OrganoIDNet dataset.
+
+    Args:
+        path: Filepath to the folder where the downloaded data will be saved.
+        split: The data split to use.
+        download: Whether to download the data if it is not present.
+
+    Returns:
+        The filepath where the data is downloaded.
+    """
     splits = ["Training", "Validation", "Test"]
     assert split in splits
 
@@ -51,7 +70,20 @@ def get_organoidnet_data(path, split, download):
     return data_dir
 
 
-def _get_data_paths(path, split, download):
+def get_organoidnet_paths(
+    path: Union[os.PathLike, str], split: str, download: bool = False
+) -> Tuple[List[str], List[str]]:
+    """Get paths to the OrganoIDNet data.
+
+    Args:
+        path: Filepath to the folder where the downloaded data will be saved.
+        split: The data split to use.
+        download: Whether to download the data if it is not present.
+
+    Returns:
+        List of filepaths for the image data.
+        List of filepaths for the label data.
+    """
     data_dir = get_organoidnet_data(path=path, split=split, download=download)
 
     image_paths = sorted(glob(os.path.join(data_dir, "Images", "*.tif")))
@@ -61,18 +93,21 @@ def _get_data_paths(path, split, download):
 
 
 def get_organoidnet_dataset(
-    path: Union[os.PathLike, str],
-    split: str,
-    patch_shape: Tuple[int, int],
-    download: bool = False,
-    **kwargs
-):
-    """Dataset for the segmentation of panceratic organoids.
+    path: Union[os.PathLike, str], split: str, patch_shape: Tuple[int, int], download: bool = False, **kwargs
+) -> Dataset:
+    """Get the OrganoIDNet dataset for organoid segmentation in microscopy images.
 
-    This dataset is from the publication https://doi.org/10.1007/s13402-024-00958-2.
-    Please cite it if you use this dataset for a publication.
+    Args:
+        path: Filepath to a folder where the downloaded data will be saved.
+        split: The data split to use.
+        patch_shape: The patch shape to use for training.
+        download: Whether to download the data if it is not present.
+        kwargs: Additional keyword arguments for `torch_em.default_segmentation_dataset`.
+
+    Returns:
+        The segmentation dataset.
     """
-    image_paths, label_paths = _get_data_paths(path=path, split=split, download=download)
+    image_paths, label_paths = get_organoidnet_paths(path, split, download)
 
     return torch_em.default_segmentation_dataset(
         raw_paths=image_paths,
@@ -92,17 +127,22 @@ def get_organoidnet_loader(
     batch_size: int,
     download: bool = False,
     **kwargs
-):
-    """Dataloader for the segmentation of pancreatic organoids in brightfield images.
-    See `get_organoidnet_dataset` for details.
+) -> DataLoader:
+    """Get the OrganoIDNet dataset for organoid segmentation in microscopy images.
+
+    Args:
+        path: Filepath to a folder where the downloaded data will be saved.
+        split: The data split to use.
+        patch_shape: The patch shape to use for training.
+        batch_size: The batch size for training.
+        download: Whether to download the data if it is not present.
+        kwargs: Additional keyword arguments for `torch_em.default_segmentation_dataset` or for the PyTorch DataLoader.
+
+    Returns:
+        The DataLoader.
     """
     ds_kwargs, loader_kwargs = util.split_kwargs(torch_em.default_segmentation_dataset, **kwargs)
     dataset = get_organoidnet_dataset(
-        path=path,
-        split=split,
-        patch_shape=patch_shape,
-        download=download,
-        **ds_kwargs
+        path=path, split=split, patch_shape=patch_shape, download=download, **ds_kwargs
     )
-    loader = torch_em.get_data_loader(dataset=dataset, batch_size=batch_size, **loader_kwargs)
-    return loader
+    return torch_em.get_data_loader(dataset=dataset, batch_size=batch_size, **loader_kwargs)

--- a/torch_em/data/datasets/light_microscopy/orgasegment.py
+++ b/torch_em/data/datasets/light_microscopy/orgasegment.py
@@ -8,7 +8,7 @@ Please cite it if you use this dataset for your research.
 import os
 import shutil
 from glob import glob
-from typing import Tuple, Union, Literal
+from typing import Tuple, Union, Literal, List
 
 from torch.utils.data import Dataset, DataLoader
 
@@ -54,7 +54,22 @@ def get_orgasegment_data(
     return data_dir
 
 
-def _get_data_paths(path, split, download):
+def get_orgasegment_paths(
+    path: Union[os.PathLike, str],
+    split: Literal["train", "val", "eval"],
+    download: bool = False
+) -> Tuple[List[str], List[str]]:
+    """Get paths for the OrgaSegment data.
+
+    Args:
+        path: Filepath to a folder where the downloaded data will be saved.
+        split: The split to download. Either 'train', 'val or 'eval'.
+        download: Whether to download the data if it is not present.
+
+    Returns:
+        List of filepaths to the image data.
+        List of filepaths to the label data.
+    """
     data_dir = get_orgasegment_data(path=path, split=split, download=download)
 
     image_paths = sorted(glob(os.path.join(data_dir, "*_img.jpg")))
@@ -88,11 +103,10 @@ def get_orgasegment_dataset(
     """
     assert split in ["train", "val", "eval"]
 
-    image_paths, label_paths = _get_data_paths(path=path, split=split, download=download)
+    image_paths, label_paths = get_orgasegment_paths(path=path, split=split, download=download)
 
-    kwargs, _ = util.add_instance_label_transform(
-        kwargs, add_binary_target=True, binary=binary, boundaries=boundaries,
-    )
+    kwargs, _ = util.add_instance_label_transform(kwargs, add_binary_target=True, binary=binary, boundaries=boundaries)
+
     return torch_em.default_segmentation_dataset(
         raw_paths=image_paths,
         raw_key=None,
@@ -138,5 +152,4 @@ def get_orgasegment_loader(
         download=download,
         **ds_kwargs
     )
-    loader = torch_em.get_data_loader(dataset=dataset, batch_size=batch_size, **loader_kwargs)
-    return loader
+    return torch_em.get_data_loader(dataset=dataset, batch_size=batch_size, **loader_kwargs)

--- a/torch_em/data/datasets/light_microscopy/plantseg.py
+++ b/torch_em/data/datasets/light_microscopy/plantseg.py
@@ -138,6 +138,12 @@ def get_plantseg_data(path: Union[os.PathLike, str], download: bool, name: str, 
     return out_path
 
 
+def _get_plantseg_paths(data_path):
+    file_paths = glob(os.path.join(data_path, "*.h5"))
+    file_paths.sort()
+    return file_paths
+
+
 def get_plantseg_dataset(
     path: Union[os.PathLike, str],
     name: str,
@@ -168,8 +174,7 @@ def get_plantseg_dataset(
     assert len(patch_shape) == 3
     data_path = get_plantseg_data(path, download, name, split)
 
-    file_paths = glob(os.path.join(data_path, "*.h5"))
-    file_paths.sort()
+    file_paths = _get_plantseg_paths(data_path)
 
     kwargs, _ = util.add_instance_label_transform(
         kwargs, add_binary_target=binary, binary=binary, boundaries=boundaries,

--- a/torch_em/data/datasets/light_microscopy/plantseg.py
+++ b/torch_em/data/datasets/light_microscopy/plantseg.py
@@ -113,14 +113,14 @@ def _fix_inconsistent_volumes(data_path, name, split):
             labels[...] = resized_labels
 
 
-def get_plantseg_data(path: Union[os.PathLike, str], download: bool, name: str, split: str) -> str:
+def get_plantseg_data(path: Union[os.PathLike, str], name: str, split: str, download: bool = False) -> str:
     """Download the PlantSeg training data.
 
     Args:
         path: Filepath to a folder where the downloaded data will be saved.
-        download: Whether to download the data if it is not present.
         name: The name of the data to load. Either 'root', 'nuclei' or 'ovules'.
         split: The split to download. Either 'train', 'val' or 'test'.
+        download: Whether to download the data if it is not present.
 
     Returns:
         The filepath to the training data.
@@ -138,9 +138,25 @@ def get_plantseg_data(path: Union[os.PathLike, str], download: bool, name: str, 
     return out_path
 
 
-def _get_plantseg_paths(data_path):
-    file_paths = glob(os.path.join(data_path, "*.h5"))
-    file_paths.sort()
+def get_plantseg_paths(
+    path: Union[os.PathLike, str],
+    name: str,
+    split: str,
+    download: bool = False
+) -> List[str]:
+    """Get paths to the PlantSeg data.
+
+    Args:
+        path: Filepath to a folder where the downloaded data will be saved.
+        name: The name of the data to load. Either 'root', 'nuclei' or 'ovules'.
+        split: The split to download. Either 'train', 'val' or 'test'.
+        download: Whether to download the data if it is not present.
+
+    Returns:
+        List of filepaths for the data.
+    """
+    data_path = get_plantseg_data(path, download, name, split)
+    file_paths = sorted(glob(os.path.join(data_path, "*.h5")))
     return file_paths
 
 
@@ -172,17 +188,22 @@ def get_plantseg_dataset(
        The segmentation dataset.
     """
     assert len(patch_shape) == 3
-    data_path = get_plantseg_data(path, download, name, split)
 
-    file_paths = _get_plantseg_paths(data_path)
+    file_paths = get_plantseg_paths(path, name, split, download)
 
     kwargs, _ = util.add_instance_label_transform(
         kwargs, add_binary_target=binary, binary=binary, boundaries=boundaries,
         offsets=offsets, binary_is_exclusive=False
     )
 
-    raw_key, label_key = "raw", "label"
-    return torch_em.default_segmentation_dataset(file_paths, raw_key, file_paths, label_key, patch_shape, **kwargs)
+    return torch_em.default_segmentation_dataset(
+        raw_paths=file_paths,
+        raw_key="raw",
+        label_paths=file_paths,
+        label_key="label",
+        patch_shape=patch_shape,
+        **kwargs
+    )
 
 
 # TODO add support for ignore label, key: "/label_with_ignore"
@@ -215,13 +236,9 @@ def get_plantseg_loader(
     Returns:
        The DataLoader.
     """
-    ds_kwargs, loader_kwargs = util.split_kwargs(
-        torch_em.default_segmentation_dataset, **kwargs
-    )
+    ds_kwargs, loader_kwargs = util.split_kwargs(torch_em.default_segmentation_dataset, **kwargs)
     dataset = get_plantseg_dataset(
-        path, name, split, patch_shape,
-        download=download, offsets=offsets, boundaries=boundaries, binary=binary,
-        **ds_kwargs
+        path, name, split, patch_shape, download=download, offsets=offsets,
+        boundaries=boundaries, binary=binary, **ds_kwargs
     )
-    loader = torch_em.get_data_loader(dataset, batch_size, **loader_kwargs)
-    return loader
+    return torch_em.get_data_loader(dataset, batch_size, **loader_kwargs)

--- a/torch_em/data/datasets/light_microscopy/tissuenet.py
+++ b/torch_em/data/datasets/light_microscopy/tissuenet.py
@@ -10,7 +10,7 @@ and download it yourself.
 import os
 from glob import glob
 from tqdm import tqdm
-from typing import Tuple, Union
+from typing import Tuple, Union, List
 
 import numpy as np
 import pandas as pd
@@ -60,11 +60,7 @@ def _create_dataset(path, zip_path):
         _create_split(path, split)
 
 
-def get_tissuenet_data(
-    path: Union[os.PathLike, str],
-    split: str,
-    download: bool = False,
-):
+def get_tissuenet_data(path: Union[os.PathLike, str], split: str, download: bool = False) -> str:
     """Download the TissueNet dataset.
 
     NOTE: Automatic download is not supported for TissueNet datset.
@@ -97,6 +93,25 @@ def get_tissuenet_data(
     return split_folder
 
 
+def get_tissuenet_paths(path: Union[os.PathLike, str], split: str, download: bool = False) -> List[str]:
+    """Get paths to the TissueNet data.
+
+    Args:
+        path: Filepath to a folder where the downloaded data will be saved.
+        split: The data split to use. Either 'train', 'val' or 'test'.
+        download: Whether to download the data if it is not present.
+
+    Returns:
+        List of filepaths for the data.
+    """
+    split_folder = get_tissuenet_data(path, split, download)
+    assert os.path.exists(split_folder)
+    data_paths = glob(os.path.join(split_folder, "*.zarr"))
+    assert len(data_paths) > 0
+
+    return data_paths
+
+
 def get_tissuenet_dataset(
     path: Union[os.PathLike, str],
     split: str,
@@ -123,19 +138,21 @@ def get_tissuenet_dataset(
     assert raw_channel in ("nucleus", "cell", "rgb")
     assert label_channel in ("nucleus", "cell")
 
-    split_folder = get_tissuenet_data(path, split, download)
-    assert os.path.exists(split_folder)
-    data_path = glob(os.path.join(split_folder, "*.zarr"))
-    assert len(data_path) > 0
-
-    raw_key, label_key = f"raw/{raw_channel}", f"labels/{label_channel}"
+    data_paths = get_tissuenet_paths(path, split, download)
 
     with_channels = True if raw_channel == "rgb" else False
     kwargs = util.update_kwargs(kwargs, "with_channels", with_channels)
     kwargs = util.update_kwargs(kwargs, "is_seg_dataset", True)
     kwargs = util.update_kwargs(kwargs, "ndim", 2)
 
-    return torch_em.default_segmentation_dataset(data_path, raw_key, data_path, label_key, patch_shape, **kwargs)
+    return torch_em.default_segmentation_dataset(
+        raw_paths=data_paths,
+        raw_key=f"raw/{raw_channel}",
+        label_paths=data_paths,
+        label_key=f"labels/{label_channel}",
+        patch_shape=patch_shape,
+        **kwargs
+    )
 
 
 # TODO enable loading specific tissue types etc. (from the 'meta' attributes)
@@ -168,5 +185,4 @@ def get_tissuenet_loader(
     dataset = get_tissuenet_dataset(
         path, split, patch_shape, raw_channel, label_channel, download, **ds_kwargs
     )
-    loader = torch_em.get_data_loader(dataset, batch_size, **loader_kwargs)
-    return loader
+    return torch_em.get_data_loader(dataset, batch_size, **loader_kwargs)


### PR DESCRIPTION
This PR extends support for the possibility of having paths to input images / volumes. This is in favor of https://github.com/computational-cell-analytics/micro-sam/pull/728 to avoid writing additional scripts to extracts paths split-wise / data partition wise.

It's a WIP, I'll put this in review once the required (ideally all) datasets have the support for the mentioned feature.