### PR TITLE
Ignore inputs with empty labels for SIIM ACR dataset

### DIFF
--- a/torch_em/data/datasets/medical/siim_acr.py
+++ b/torch_em/data/datasets/medical/siim_acr.py
@@ -59,7 +59,8 @@ def _clean_image_and_label_paths(image_paths, gt_paths):
         return np.any(gt) and not np.all(gt)
 
     paths = [
-        (ip, gp) for ip, gp in tqdm(zip(image_paths, gt_paths), total=len(image_paths)) if _has_multiple_classes(gp)
+        (ip, gp) for ip, gp in tqdm(zip(image_paths, gt_paths), total=len(image_paths), desc="Verifying labels")
+        if _has_multiple_classes(gp)
     ]
     image_paths = [p[0] for p in paths]
     gt_paths = [p[1] for p in paths]


### PR DESCRIPTION
This PR takes care of a minor inconsistency (which was handled with samplers as expected, however is hard to work with benchmarking other methods). I decided to make it consistent and consider only inputs valid which have any annotations (for reference, a huge portion of images do not have foreground labels).

I'll go ahead and merge this once the tests pass!