### PR TITLE
Add argument to get expected image-label pairs for CBIS DDSM data

### DIFF
--- a/torch_em/data/datasets/medical/cbis_ddsm.py
+++ b/torch_em/data/datasets/medical/cbis_ddsm.py
@@ -63,6 +63,7 @@ def get_cbis_ddsm_paths(
         task: The choice of labels for the specified task.
         tumour_type: The choice of tumour type.
         download: Whether to download the data if it is not present.
+        ignore_mismatching_pairs: Whether to avoid returning paths to image-label pairs of mismatching shape.
 
     Returns:
         List of filepaths for the image data.


### PR DESCRIPTION
This PR takes care of an additional (optional) argument to avoid getting image-label pairs with mismatching shapes. This is GTG from my side. I'll go ahead and merge this once the tests pass!