### PR TITLE
Make splits for lizard dataset

### DIFF
--- a/scripts/datasets/histopathology/check_lizard.py
+++ b/scripts/datasets/histopathology/check_lizard.py
@@ -15,7 +15,8 @@ def check_lizard():
         path=os.path.join(ROOT, "lizard"),
         patch_shape=(512, 512),
         batch_size=1,
-        download=True
+        download=True,
+        split="val",
     )
     check_loader(loader, 8, rgb=True, instance_labels=True)
 

--- a/torch_em/data/datasets/histopathology/lizard.py
+++ b/torch_em/data/datasets/histopathology/lizard.py
@@ -23,7 +23,7 @@ from .. import util
 
 
 def create_split_list(path, split):
-    df = pd.read_csv(os.path.join(path, 'lizard_labels/Lizard_Labels/info.csv'))
+    df = pd.read_csv(os.path.join(path, 'lizard_labels', 'Lizard_Labels/info.csv'))
     split_list = []
     for i in df.index:
         image_split = df['Split'].iloc[i]

--- a/torch_em/data/datasets/histopathology/lizard.py
+++ b/torch_em/data/datasets/histopathology/lizard.py
@@ -105,11 +105,14 @@ def get_lizard_data(path: Union[os.PathLike, str], split: Literal["train", "val"
     rmtree(os.path.join(path, "overlay"))
 
 
-def get_lizard_paths(path: Union[os.PathLike], split, download: bool = False) -> List[str]:
+def get_lizard_paths(
+    path: Union[os.PathLike], split: Literal["train", "val", "test"], download: bool = False
+) -> List[str]:
     """Get paths to the Lizard data.
 
     Args:
         path: Filepath to a folder where the downloaded data will be saved.
+        split: The choice of data splits.
         download: Whether to download the data if it is not present.
 
     Returns:
@@ -121,7 +124,11 @@ def get_lizard_paths(path: Union[os.PathLike], split, download: bool = False) ->
 
 
 def get_lizard_dataset(
-    path: Union[os.PathLike, str], patch_shape: Tuple[int, int], split: str, download: bool = False, **kwargs
+    path: Union[os.PathLike, str],
+    patch_shape: Tuple[int, int],
+    split: Literal["train", "val", "test"],
+    download: bool = False,
+    **kwargs
 ) -> Dataset:
     """Get the Lizard dataset for nucleus segmentation.
 
@@ -155,7 +162,7 @@ def get_lizard_loader(
     path: Union[os.PathLike, str],
     batch_size: int,
     patch_shape: Tuple[int, int],
-    split: str,
+    split: Literal["train", "val", "test"],
     download: bool = False,
     **kwargs
 ) -> DataLoader:

--- a/torch_em/data/datasets/histopathology/lizard.py
+++ b/torch_em/data/datasets/histopathology/lizard.py
@@ -8,11 +8,13 @@ Please cite it if you use this dataset for your research.
 import os
 from glob import glob
 from tqdm import tqdm
+from pathlib import Path
 from shutil import rmtree
-from typing import Tuple, Union, List
+from natsort import natsorted
+from typing import Tuple, Union, List, Literal
+
 import pandas as pd
 import imageio.v3 as imageio
-
 from scipy.io import loadmat
 
 from torch.utils.data import Dataset, DataLoader
@@ -22,28 +24,28 @@ import torch_em
 from .. import util
 
 
-def create_split_list(path, split):
-    df = pd.read_csv(os.path.join(path, 'lizard_labels', 'Lizard_Labels/info.csv'))
-    split_list = []
-    for i in df.index:
-        image_split = df['Split'].iloc[i]
-        if image_split == int(split[-1]):
-            split_list.append(df['Filename'].iloc[i])
+SPLIT_MAP = {"train": 1, "val": 2, "test": 3}
+
+
+def _create_split_list(path, split):
+    df = pd.read_csv(os.path.join(path, 'lizard_labels', 'Lizard_Labels', 'info.csv'))
+    split_list = [df['Filename'].iloc[i] for i in df.index if df['Split'].iloc[i] == SPLIT_MAP[split]]
     return split_list
 
 
-def _extract_images(image_folder, label_folder, output_dir, split):
+def _extract_images(split, image_folder, label_folder, output_dir):
     import h5py
 
     image_files = glob(os.path.join(image_folder, "*.png"))
-    split_list = create_split_list(output_dir, split)
-    output_path = os.path.join(output_dir, split)
-    os.makedirs(output_path, exist_ok=True)
-    for image_file in tqdm(image_files, desc=f"Extract images from {image_folder}"):
-        fname = os.path.basename(image_file)
-        if os.path.splitext(fname)[0] not in split_list:
+    split_list = _create_split_list(output_dir, split)
+    os.makedirs(os.path.join(output_dir, split), exist_ok=True)
+
+    for image_file in tqdm(image_files, desc=f"Extract images from {os.path.abspath(image_folder)}"):
+        fname = Path(os.path.basename(image_file))
+        if fname.stem not in split_list:
             continue
-        label_file = os.path.join(label_folder, fname.replace(".png", ".mat"))
+
+        label_file = os.path.join(label_folder, fname.with_suffix(".mat"))
         assert os.path.exists(label_file), label_file
 
         image = imageio.imread(image_file)
@@ -57,29 +59,32 @@ def _extract_images(image_folder, label_folder, output_dir, split):
         image = image.transpose((2, 0, 1))
         assert image.shape[1:] == segmentation.shape
 
-        output_file = os.path.join(output_path, fname.replace(".png", ".h5"))
+        output_file = os.path.join(output_dir, split, fname.with_suffix(".h5"))
         with h5py.File(output_file, "a") as f:
             f.create_dataset("image", data=image, compression="gzip")
             f.create_dataset("labels/segmentation", data=segmentation, compression="gzip")
             f.create_dataset("labels/classes", data=classes, compression="gzip")
 
 
-def get_lizard_data(path, download, split):
+def get_lizard_data(path: Union[os.PathLike, str], split: Literal["train", "val", "test"], download: bool = False):
     """Download the Lizard dataset for nucleus segmentation.
 
     Args:
         path: Filepath to a folder where the downloaded data will be saved.
+        split: The choice of data split.
         download: Whether to download the data if it is not present.
     """
-    util.download_source_kaggle(path=path, dataset_name="aadimator/lizard-dataset", download=download)
-    zip_path = os.path.join(path, "lizard-dataset.zip")
-    util.unzip(zip_path=zip_path, dst=path)
+    if split not in SPLIT_MAP.keys():
+        raise ValueError(f"'{split}' is not a valid split.")
 
     image_files = glob(os.path.join(path, split, "*.h5"))
     if len(image_files) > 0:
         return
 
     os.makedirs(path, exist_ok=True)
+    util.download_source_kaggle(path=path, dataset_name="aadimator/lizard-dataset", download=download)
+    zip_path = os.path.join(path, "lizard-dataset.zip")
+    util.unzip(zip_path=zip_path, dst=path)
 
     image_folder1 = os.path.join(path, "lizard_images1", "Lizard_Images1")
     image_folder2 = os.path.join(path, "lizard_images2",  "Lizard_Images2")
@@ -89,8 +94,10 @@ def get_lizard_data(path, download, split):
     assert os.path.exists(image_folder2), image_folder2
     assert os.path.exists(label_folder), label_folder
 
-    _extract_images(image_folder1, os.path.join(label_folder, "Labels"), path, split)
-    _extract_images(image_folder2, os.path.join(label_folder, "Labels"), path, split)
+    # Extract and preprocess images for all splits
+    for _split in SPLIT_MAP.keys():
+        _extract_images(_split, image_folder1, os.path.join(label_folder, "Labels"), path)
+        _extract_images(_split, image_folder2, os.path.join(label_folder, "Labels"), path)
 
     rmtree(os.path.join(path, "lizard_images1"))
     rmtree(os.path.join(path, "lizard_images2"))
@@ -108,21 +115,20 @@ def get_lizard_paths(path: Union[os.PathLike], split, download: bool = False) ->
     Returns:
         List of filepaths for the stored data.
     """
-    get_lizard_data(path, download, split)
-
-    data_paths = glob(os.path.join(path, split, "*.h5"))
-    data_paths.sort()
+    get_lizard_data(path, split, download)
+    data_paths = natsorted(glob(os.path.join(path, split, "*.h5")))
     return data_paths
 
 
 def get_lizard_dataset(
-    path: Union[os.PathLike, str], patch_shape: Tuple[int, int], split, download: bool = False, **kwargs
+    path: Union[os.PathLike, str], patch_shape: Tuple[int, int], split: str, download: bool = False, **kwargs
 ) -> Dataset:
     """Get the Lizard dataset for nucleus segmentation.
 
     Args:
         path: Filepath to a folder where the downloaded data will be saved.
         patch_shape: The patch shape to use for training.
+        split: The choice of data split.
         download: Whether to download the data if it is not present.
         kwargs: Additional keyword arguments for `torch_em.default_segmentation_dataset`.
 
@@ -146,14 +152,20 @@ def get_lizard_dataset(
 # TODO implement loading the classification labels
 # TODO implement selecting different tissue types
 def get_lizard_loader(
-    path: Union[os.PathLike, str], patch_shape: Tuple[int, int], batch_size: int, split: str, download: bool = False, **kwargs
+    path: Union[os.PathLike, str],
+    batch_size: int,
+    patch_shape: Tuple[int, int],
+    split: str,
+    download: bool = False,
+    **kwargs
 ) -> DataLoader:
     """Get the Lizard dataloader for nucleus segmentation.
 
     Args:
         path: Filepath to a folder where the downloaded data will be saved.
-        patch_shape: The patch shape to use for training.
         batch_size: The batch size for training.
+        patch_shape: The patch shape to use for training.
+        split: The choice of data split.
         download: Whether to download the data if it is not present.
         kwargs: Additional keyword arguments for `torch_em.default_segmentation_dataset` or for the PyTorch DataLoader.
 
@@ -161,5 +173,5 @@ def get_lizard_loader(
         The DataLoader.
     """
     ds_kwargs, loader_kwargs = util.split_kwargs(torch_em.default_segmentation_dataset, **kwargs)
-    ds = get_lizard_dataset(path, patch_shape, download=download, split=split, **ds_kwargs)
-    return torch_em.get_data_loader(ds, batch_size=batch_size, **loader_kwargs)
+    ds = get_lizard_dataset(path, patch_shape, split, download, **ds_kwargs)
+    return torch_em.get_data_loader(ds, batch_size, **loader_kwargs)


### PR DESCRIPTION
Superseeds and closes https://github.com/constantinpape/torch-em/pull/433.

This PR takes care of creating splits for train-val-test (provided by the data curators) (thanks for @titusgriebel for taking care of this).

PS @titusgriebel: I decided to map splits 1, 2, 3 to `train`, `val` and `test` split names, respectively (with them respectively having 70, 70 and 98 samples). We can discuss if you think another mapping makes more sense. For now, let's stick to this for simplicity. Changing the split maps should be straight forward.

I'll go ahead and merge this once the tests pass.