### PR TITLE
Minor fix to removing alpha channel in TNBC data

### DIFF
--- a/torch_em/data/datasets/histopathology/tnbc.py
+++ b/torch_em/data/datasets/histopathology/tnbc.py
@@ -38,7 +38,10 @@ def _preprocess_images(path):
 
     for rpath, lpath in tqdm(zip(raw_paths, label_paths), desc="Preprocessing images", total=len(raw_paths)):
         raw = imageio.imread(rpath)
-        raw = raw[..., :-1].transpose(2, 0, 1)  # remove 4th alpha channel (seems like an empty channel).
+        if raw.ndim == 3 and raw.shape[-1] == 4:
+            raw = raw[..., :-1]  # remove 4th alpha channel (seems like an empty channel).
+
+        raw = raw.transpose(2, 0, 1)
         label = imageio.imread(lpath)
 
         vol_path = os.path.join(preprocessed_dir, f"{Path(lpath).stem}.h5")


### PR DESCRIPTION
This PR takes care of a super minor fix in preprocessing TNBC inputs. I previously assumed that all images had 4 channels, but that does not seem to be true. I added a check now on top to remove the alpha channel from images where it is not relevant. I'll merge this once the tests pass!