### PR TITLE
Add download functionality support for `synapse` hosted datasets

### DIFF
--- a/torch_em/data/datasets/light_microscopy/cvz_fluo.py
+++ b/torch_em/data/datasets/light_microscopy/cvz_fluo.py
@@ -1,13 +1,9 @@
 """The CVZ-Fluo dataset contains annotations for cell and nuclei segmentation in
 fluorescence microscopy images.
 
-NOTE: You need to install 'synapseclient', create an account and authentication token on Synapse,
-and follow the documentation to create your authentication config: https://python-docs.synapse.org/tutorials/authentication/
-and install using 'synapse get -r syn27624812'.
-
 The dataset is from the publication https://doi.org/10.1038/s41597-023-02108-z.
 Please cite it if you use this dataset for your research.
-"""  # noqa
+"""
 
 import os
 from glob import glob
@@ -31,20 +27,18 @@ URL = "https://www.synapse.org/Synapse:syn27624812/"
 
 
 def get_cvz_fluo_data(path: Union[os.PathLike, str], download: bool = False):
-    """Obtain the CVZ-Fluo dataset.
+    """DOwnload the CVZ-Fluo dataset.
 
     Args:
         path: Filepath to a folder where the downloaded data is saved.
         download: Whether to download the data if it is not present.
     """
-    if download:
-        raise NotImplementedError("Automatic download is not implemented for this dataset.")
-
     data_dir = os.path.join(path, r"Annotation Panel Table.xlsx")
-    if os.path.exists(data_dir):
-        return
-    else:
-        raise AssertionError(f"The dataset is not downloaded. Please download it manually from '{URL}'.")
+    if not os.path.exists(data_dir):
+        # Download the dataset from 'synapse'.
+        util.download_source_synapse(path=path, entity="syn27624812", download=download)
+
+    return
 
 
 def _preprocess_labels(label_paths):

--- a/torch_em/data/datasets/light_microscopy/cvz_fluo.py
+++ b/torch_em/data/datasets/light_microscopy/cvz_fluo.py
@@ -27,7 +27,7 @@ URL = "https://www.synapse.org/Synapse:syn27624812/"
 
 
 def get_cvz_fluo_data(path: Union[os.PathLike, str], download: bool = False):
-    """DOwnload the CVZ-Fluo dataset.
+    """Download the CVZ-Fluo dataset.
 
     Args:
         path: Filepath to a folder where the downloaded data is saved.

--- a/torch_em/data/datasets/light_microscopy/cvz_fluo.py
+++ b/torch_em/data/datasets/light_microscopy/cvz_fluo.py
@@ -35,6 +35,7 @@ def get_cvz_fluo_data(path: Union[os.PathLike, str], download: bool = False):
     """
     data_dir = os.path.join(path, r"Annotation Panel Table.xlsx")
     if not os.path.exists(data_dir):
+        os.makedirs(path, exist_ok=True)
         # Download the dataset from 'synapse'.
         util.download_source_synapse(path=path, entity="syn27624812", download=download)
 

--- a/torch_em/util/debug.py
+++ b/torch_em/util/debug.py
@@ -136,7 +136,7 @@ def check_trainer(
 
 
 def check_loader(
-    loader: torch.utils.data.Dataloader,
+    loader: torch.utils.data.DataLoader,
     n_samples: int,
     instance_labels: bool = False,
     plt: bool = False,


### PR DESCRIPTION
This PR adds supports for data download hosted on `synapse` (ttps://www.synapse.org). GTG from my side!

And closes https://github.com/constantinpape/torch-em/issues/447.