### PR TITLE
Fix return type for BUSI data paths

### DIFF
--- a/torch_em/data/datasets/medical/busi.py
+++ b/torch_em/data/datasets/medical/busi.py
@@ -47,7 +47,7 @@ def get_busi_paths(
     path: Union[os.PathLike, str],
     category: Optional[Literal["normal", "benign", "malignant"]] = None,
     download: bool = False
-) -> Tuple[List[str, List[str]]]:
+) -> Tuple[List[str], List[str]]:
     """Get paths to the BUSI data.
 
     Args:


### PR DESCRIPTION
Minor fix to BUSI data paths' return type (this broke the doc builds). I'll merge this!