### PR TITLE
Minor fix to generate color maps for instances with no background

### DIFF
--- a/torch_em/util/util.py
+++ b/torch_em/util/util.py
@@ -410,7 +410,9 @@ def get_random_colors(labels: np.ndarray) -> colors.ListedColormap:
     Returns:
         The color map.
     """
-    n_labels = len(np.unique(labels)) - 1
-    cmap = [[0, 0, 0]] + np.random.rand(n_labels, 3).tolist()
+    unique_labels = np.unique(labels)
+    have_zero = 0 in unique_labels
+    cmap = [[0, 0, 0]] if have_zero else []
+    cmap += np.random.rand(len(unique_labels), 3).tolist()
     cmap = colors.ListedColormap(cmap)
     return cmap


### PR DESCRIPTION
This PR fixes the random color generator for plotting instance segmentation. I'll merge this once the tests pass!

cc: @constantinpape 