### PR TITLE
Minor fix to CellMap data - remove test crops

### DIFF
--- a/torch_em/data/datasets/electron_microscopy/cellmap.py
+++ b/torch_em/data/datasets/electron_microscopy/cellmap.py
@@ -161,7 +161,7 @@ def _download_cellmap_data(path, crops, resolution, padding, download=False):
 
         if isinstance(crop.gt_source, TestCropRow):
             # Choose the scale ratio threshold (from the original scripts)
-            ratio_threshold = 0.8
+            ratio_threshold = 0.8  # NOTE: hard-coded atm to follow along the original data download code logic.
 
             # Choose the matching resolution level with marked GT.
             em_level = next(

--- a/torch_em/data/datasets/electron_microscopy/cellmap.py
+++ b/torch_em/data/datasets/electron_microscopy/cellmap.py
@@ -382,6 +382,7 @@ def get_cellmap_paths(
     resolution: str = "s0",
     padding: int = 64,
     download: bool = False,
+    return_test_crops: bool = False,
 ) -> List[str]:
     """Get the paths to CellMap training data.
 
@@ -397,12 +398,13 @@ def get_cellmap_paths(
             You can set it to '0' for no padding at all.
             For pixel regions without annotations, it labels the masks with id '-1'.
         download: Whether to download the data if it is not present.
+        return_test_crops: Whether to forcefully return the filepaths of the test crops for other analysis.
 
     Returns:
         List of the cropped volume data paths.
     """
 
-    if ("test" in crops if isinstance(crops, (List, Tuple)) else crops == "test"):
+    if not return_test_crops and ("test" in crops if isinstance(crops, (List, Tuple)) else crops == "test"):
         raise NotImplementedError("The 'test' crops cannot be used in the dataloader.")
 
     # Get the CellMap data crops.

--- a/torch_em/data/datasets/electron_microscopy/cellmap.py
+++ b/torch_em/data/datasets/electron_microscopy/cellmap.py
@@ -65,15 +65,12 @@ def _download_cellmap_data(path, crops, resolution, padding, download=False):
     crops_from_manifest = fetch_crop_manifest()
 
     # Get the desired crop info from the manifest.
-    if crops in ["all", "test"]:
-        test_crops = get_test_crops()
-        log.info(f"Found '{len(test_crops)}' test crops.")
-
-    # Fetch all the crop manifests.
     if crops == "all":
-        crops_parsed = crops_from_manifest + test_crops
+        crops_parsed = crops_from_manifest
     elif crops == "test":
-        crops_parsed = test_crops
+        raise NotImplementedError("The test crops do not have GT. Hence we do not allow using them in our setup.")
+        crops_parsed = get_test_crops()
+        log.info(f"Found '{len(crops_parsed)}' test crops.")
     else:  # Otherwise, custom crops are parsed.
         crops_split = tuple(int(x) for x in crops.split(","))
         crops_parsed = tuple(filter(lambda v: v.id in crops_split, crops_from_manifest))
@@ -328,6 +325,8 @@ def get_cellmap_data(
     if _data_path is None or len(_data_path) == 0:
         raise RuntimeError("Something went wrong. Please read the information logged above.")
 
+    assert len(final_crops) > 0, "There seems to be no valid crops in the list."
+
     return data_path, final_crops
 
 
@@ -365,6 +364,11 @@ def get_cellmap_paths(
 
     # Get all crops.
     volume_paths = [os.path.join(data_path, f"crop_{c}.h5") for c in crops]
+
+    # Check whether all volume paths exist.
+    for volume_path in volume_paths:
+        if not os.path.exists(volume_path):
+            raise FileNotFoundError(f"The volume '{volume_path}' could not be found.")
 
     return volume_paths
 


### PR DESCRIPTION
This PR closes https://github.com/constantinpape/torch-em/issues/511 by removing the test crops from the manifest, as they do not have ground truth masks, hence we do not want them for now.

GTG from my side!