### PR TITLE
Update handling label download for larger crops in CellMap

### DIFF
--- a/torch_em/data/datasets/electron_microscopy/cellmap.py
+++ b/torch_em/data/datasets/electron_microscopy/cellmap.py
@@ -254,6 +254,7 @@ def _download_cellmap_data(path, crops, resolution, padding, download=False):
 
             # Store inputs.
             f.create_dataset(name="raw_crop", data=em_crop, dtype=em_crop.dtype, compression="gzip")
+            log.info(f"Saved EM data crop for crop '{crop.id}'.")
 
             def _fetch_and_write_label(label_name):
                 gt_crop = gt_source_group[f"{label_name}/{gt_level}"][:]

--- a/torch_em/data/datasets/electron_microscopy/cellmap.py
+++ b/torch_em/data/datasets/electron_microscopy/cellmap.py
@@ -280,11 +280,18 @@ def _download_cellmap_data(path, crops, resolution, padding, download=False):
                 return label_name
 
             if gt_level is not None:
-                with ThreadPoolExecutor() as pool:
-                    futures = {pool.submit(_fetch_and_write_label, name): name for name in crop_group_inventory}
-                    for future in as_completed(futures):
-                        label_name = future.result()
-                        log.info(f"Saved ground truth crop '{crop.id}' for '{label_name}'.")
+                # For this one (large) crop in particular, we store labels in serial
+                # as multiple threads cannot handle it and silently crash.
+                if crop.id == 247:
+                    for name in crop_group_inventory:
+                        _fetch_and_write_label(name)
+                        log.info(f"Saved ground truth crop '{crop.id}' for '{name}'.")
+                else:
+                    with ThreadPoolExecutor() as pool:
+                        futures = {pool.submit(_fetch_and_write_label, name): name for name in crop_group_inventory}
+                        for future in as_completed(futures):
+                            label_name = future.result()
+                            log.info(f"Saved ground truth crop '{crop.id}' for '{label_name}'.")
 
         log.info(f"Saved crop '{crop.id}' to '{crop_path}'.")
         log = log.unbind("crop_id", "dataset")


### PR DESCRIPTION
This PR takes care of a minor update for handling large label crops (we have identified that it's only happening with crop `247`). The threads just silently die because the crop has 16 bit depth and the threads can't take it and just silently crash.

With downloading them in sequence, this fixes the issue for this crop (goes without saying that the download takes a while, but should be fine).

GTG from my side!

cc: @lufre1 