### PR TITLE
Minor update to segmentation dataset sample count calculation

### DIFF
--- a/torch_em/data/segmentation_dataset.py
+++ b/torch_em/data/segmentation_dataset.py
@@ -1,7 +1,9 @@
 import os
 import warnings
-import numpy as np
 from typing import List, Union, Tuple, Optional, Any, Callable
+
+import numpy as np
+from math import ceil
 
 import torch
 
@@ -54,7 +56,7 @@ class SegmentationDataset(torch.utils.data.Dataset):
         if patch_shape is None:
             return 1
         else:
-            n_samples = int(np.prod([float(sh / csh) for sh, csh in zip(shape, patch_shape)]))
+            n_samples = ceil(np.prod([float(sh / csh) for sh, csh in zip(shape, patch_shape)]))
             return n_samples
 
     def __init__(


### PR DESCRIPTION
This PR takes care of a super minor update to make finding the desired length of samples subjected to the original shape of input vs desired patch shape.

We should use `ceil` here instead of classic integer casting, as the product of the shape divisions per dimension for a larger desired patch shape might be <1 (even go lower than 0.5, where rounding stops working and returns `n_samples=0` and the segmentation dataset returns nothing (which shouldn't be the case as for smaller data crops with larger patch shape request should be handled as we allow padding the volume to the patch shape).

Puff, too much text, sorry!

GTG from my side!

PS. This was reported by @lufre1! With this fix, things should work on super small crops as expected now!

cc: @constantinpape 