### PR TITLE
Add AxonEM data

### DIFF
--- a/scripts/datasets/electron_microscopy/check_axonem.py
+++ b/scripts/datasets/electron_microscopy/check_axonem.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+from torch_em.util.debug import check_loader
+from torch_em.data import MinInstanceSampler
+from torch_em.data.datasets import get_axonem_loader
+
+
+sys.path.append("..")
+
+
+def check_axonem():
+    # from util import ROOT
+    ROOT = "/mnt/vast-nhr/projects/cidas/cca/data"
+
+    loader = get_axonem_loader(
+        path=os.path.join(ROOT, "axonem"),
+        batch_size=2,
+        patch_shape=(16, 512, 512),
+        download=True,
+        sampler=MinInstanceSampler(min_num_instances=3)
+    )
+    check_loader(loader, 8, instance_labels=True, plt=True, save_path="./axonem.png")
+
+
+if __name__ == "__main__":
+    check_axonem()

--- a/torch_em/data/datasets/electron_microscopy/__init__.py
+++ b/torch_em/data/datasets/electron_microscopy/__init__.py
@@ -1,6 +1,7 @@
 from .aimseg import get_aimseg_loader, get_aimseg_dataset
 from .asem import get_asem_loader, get_asem_dataset
 from .axondeepseg import get_axondeepseg_loader, get_axondeepseg_dataset
+from .axonem import get_axonem_loader, get_axonem_dataset
 from .betaseg import get_betaseg_loader, get_betaseg_dataset
 from .cellmap import get_cellmap_loader, get_cellmap_dataset
 from .cem import get_mitolab_loader

--- a/torch_em/data/datasets/electron_microscopy/axonem.py
+++ b/torch_em/data/datasets/electron_microscopy/axonem.py
@@ -1,0 +1,150 @@
+"""AxomEM is a datast for segmenting axons in electron microscopy.
+It contains two large annotated volumes, one from rat cortex, the other from human cortex.
+This dataset was used for the AxonEM Challenge: https://axonem.grand-challenge.org/.
+
+Please cite the publication https://arxiv.org/abs/2107.05451 if you use this dataset for your research.
+"""
+
+import os
+from glob import glob
+from typing import Union, Sequence, List, Tuple
+
+from torch.utils.data import Dataset, DataLoader
+
+import torch_em
+
+from .. import util
+
+
+URLS = {
+    "human": "https://huggingface.co/datasets/pytc/AxonEM/resolve/main/EM30-H-train-9vol-pad-20-512-512.zip",
+    "rat": "https://huggingface.co/datasets/pytc/AxonEM/resolve/main/EM30-M-train-9vol-pad-20-512-512.zip",
+}
+
+CHECKSUMS = {
+    "human": "0b53d155ff62f5e24c552bf90adce329fcf9a8fefd5c697f8bcd0312a61fda60",
+    "rat": "dae06b5dabe388ab7a0ff4e51548174f041a338d0d06bd665586aa7fdd43bac2",
+}
+
+
+def get_axonem_data(path: Union[os.PathLike, str], samples: Sequence[str], download: bool = False):
+    """Download the AxonEM training data.
+
+    Args:
+        path: Filepath to a folder where the downloaded data will be saved.
+        samples: The samples to download. The available samples are 'human' and 'rat'.
+        download: Whether to download the data if it is not present.
+    """
+    if isinstance(samples, str):
+        samples = [samples]
+
+    assert len(set(samples) - {"human", "rat"}) == 0, f"{samples}"
+    os.makedirs(path, exist_ok=True)
+
+    for sample in samples:
+        dst = os.path.join(path, sample)
+        if os.path.exists(dst):
+            continue
+
+        os.makedirs(dst, exist_ok=True)
+
+        # Download the zipfile.
+        zip_path = os.path.join(path, f"{sample}.zip")
+        util.download_source(path=zip_path, url=URLS[sample], download=download, checksum=CHECKSUMS[sample])
+
+        # Extract the h5 crops from the zipfile.
+        util.unzip(zip_path=zip_path, dst=dst, remove=True)
+
+        if sample == "rat":
+            # NOTE: We need to make a hotfix by removing a crop which does not have masks.
+            label_path = os.path.join(path, "rat", "valid_mask.h5")
+            os.remove(label_path)
+
+            # And the additional volume with no corresponding mask.
+            image_path = os.path.join(path, "rat", "im_675-800-800_pad.h5")
+            os.remove(image_path)
+
+
+def get_axonem_paths(
+    path: Union[os.PathLike, str], samples: Sequence[str], download: bool = False,
+) -> Tuple[List[str], List[str]]:
+    """Get paths for the AxonEM training data.
+
+    Args:
+        path: Filepath to a folder where the downloaded data will be saved.
+        samples: The samples to download. The available samples are 'human' and 'rat'.
+        download: Whether to download the data if it is not present.
+
+    Returns:
+        List of filepaths for the image volumes.
+        List of filepaths for the label volumes.
+    """
+    get_axonem_data(path, samples, download)
+
+    if isinstance(samples, str):
+        samples = [samples]
+
+    image_paths, label_paths = [], []
+    for sample in samples:
+        curr_image_paths = glob(os.path.join(path, sample, "im_*.h5"))
+        image_paths.extend(curr_image_paths)
+        label_paths.extend([p.replace("im_", "seg_") for p in curr_image_paths])
+
+    return image_paths, label_paths
+
+
+def get_axonem_dataset(
+    path: Union[os.PathLike, str],
+    patch_shape: Tuple[int, ...],
+    samples: Sequence[str] = ("human", "rat"),
+    download: bool = False,
+    **kwargs
+) -> Dataset:
+    """Get the AxonEM dataset for the segmentation of axons in EM.
+
+    Args:
+        path: Filepath to a folder where the downloaded data will be saved.
+        patch_shape: The patch shape to use for training.
+        samples: The samples to download. The available samples are 'human' and 'rat'.
+        download: Whether to download the data if it is not present.
+        kwargs: Additional keyword arguments for `torch_em.default_segmentation_dataset`.
+
+    Returns:
+       The segmentation dataset.
+    """
+    image_paths, label_paths = get_axonem_paths(path, samples, download)
+
+    return torch_em.default_segmentation_dataset(
+        raw_paths=image_paths,
+        raw_key="main",
+        label_paths=label_paths,
+        label_key="main",
+        patch_shape=patch_shape,
+        **kwargs
+    )
+
+
+def get_axonem_loader(
+    path: Union[os.PathLike, str],
+    batch_size: int,
+    patch_shape: Tuple[int, ...],
+    samples: Sequence[str] = ("human", "rat"),
+    download: bool = False,
+    **kwargs
+) -> DataLoader:
+    """Get the AxonEM dataloader for the segmentation of axons in EM.
+
+    Args:
+        path: Filepath to a folder where the downloaded data will be saved.
+        batch_size: The batch size for training.
+        patch_shape: The patch shape to use for training.
+        samples: The samples to download. The available samples are 'human' and 'rat'.
+        download: Whether to download the data if it is not present.
+        kwargs: Additional keyword arguments for `torch_em.default_segmentation_dataset` or for the PyTorch DataLoader.
+
+    Returns:
+        The DataLoader.
+    """
+    ds_kwargs, loader_kwargs = util.split_kwargs(torch_em.default_segmentation_dataset, **kwargs)
+    dataset = get_axonem_dataset(path, patch_shape, samples, download, **ds_kwargs)
+    return torch_em.get_data_loader(dataset, batch_size, **loader_kwargs)

--- a/torch_em/data/datasets/electron_microscopy/mitoem.py
+++ b/torch_em/data/datasets/electron_microscopy/mitoem.py
@@ -12,8 +12,8 @@ from shutil import rmtree
 from concurrent import futures
 from typing import List, Optional, Sequence, Tuple, Union
 
-import imageio
 import numpy as np
+import imageio.v3 as imageio
 
 import torch_em
 
@@ -32,6 +32,7 @@ URLS = {
         "rat": "https://huggingface.co/datasets/pytc/MitoEM/resolve/main/EM30-R-mito-train-val-v2.zip"
     }
 }
+
 CHECKSUMS = {
     "raw": {
         "human": "98fe259f36a7d8d43f99981b7a0ef8cdeba2ce2615ff91595f428ae57207a041",
@@ -50,7 +51,7 @@ def _check_data(path, sample):
     return all(os.path.exists(pp) for pp in expected_paths)
 
 
-def get_slices(folder):
+def _get_slices(folder):
     files = os.listdir(folder)
     files.sort()
     files = [os.path.splitext(ff)[0] for ff in files]
@@ -84,11 +85,11 @@ def _create_volume(out_path, im_folder, label_folder=None, z_start=None):
 
     if label_folder is None:
         assert z_start is not None
-        n_slices = len(get_slices(im_folder))
+        n_slices = len(_get_slices(im_folder))
         slices = list(range(z_start, n_slices))
     else:
         assert z_start is None
-        slices = get_slices(label_folder)
+        slices = _get_slices(label_folder)
 
     n_threads = min(16, multiprocessing.cpu_count())
     raw = _load_vol(os.path.join(im_folder, "im%04i.png"), slices, "load raw", n_threads)


### PR DESCRIPTION
This PR adds AxonEM data for axon segmentation in EM.

NOTE: This data only has small annotated crops, instead of the full volume annotations. So I adopted the (padded) crops and their corresponding labels to the dataset.

GTM from my side!