### PR TITLE
raw dataset with masks

### DIFF
--- a/test/data/test_raw_dataset.py
+++ b/test/data/test_raw_dataset.py
@@ -133,6 +133,8 @@ class TestRawDatasetWithMasks(TestRawDatasetBase, unittest.TestCase):
             self.assertEqual(patch.shape, expected_shape)
 
             # check that patches are sampled inside the ROI defined by sample mask
+            # note that the raw data and the sample mask are identical, so this checks if the
+            # positive samples from the sample mask are correct
             self.assertGreaterEqual(patch.mean().item(), min_fraction)
 
     def test_bg_mask(self):

--- a/test/data/test_raw_dataset.py
+++ b/test/data/test_raw_dataset.py
@@ -4,9 +4,14 @@ import unittest
 import h5py
 import numpy as np
 
+from torch_em.data.raw_dataset import RawDataset, RawDatasetWithMasks
 
-class TestRawDataset(unittest.TestCase):
+
+class TestRawDatasetBase:
+    """Base class to hold shared tests for RawDataset and subclasses."""
+
     path = "./data.h5"
+    dataset_class = None
 
     def tearDown(self):
         os.remove(self.path)
@@ -19,11 +24,10 @@ class TestRawDataset(unittest.TestCase):
         return shape, chunks
 
     def test_dataset_3d(self):
-        from torch_em.data import RawDataset
         raw_key = "raw"
         shape, chunks = self.create_default_data(raw_key)
         patch_shape = chunks
-        ds = RawDataset(self.path, raw_key, patch_shape=patch_shape)
+        ds = self.dataset_class(self.path, raw_key, patch_shape=patch_shape)
         self.assertEqual(ds.raw.shape, shape)
         self.assertEqual(ds._ndim, 3)
         expected_shape = (1,) + patch_shape
@@ -31,11 +35,10 @@ class TestRawDataset(unittest.TestCase):
             self.assertEqual(ds[i].shape, expected_shape)
 
     def test_dataset_2d(self):
-        from torch_em.data import RawDataset
         raw_key = "raw"
         shape, chunks = self.create_default_data(raw_key)
         patch_shape = (1, 32, 32)
-        ds = RawDataset(self.path, raw_key, patch_shape=patch_shape, ndim=2)
+        ds = self.dataset_class(self.path, raw_key, patch_shape=patch_shape, ndim=2)
         self.assertEqual(ds.raw.shape, shape)
         self.assertEqual(ds._ndim, 2)
         expected_shape = patch_shape
@@ -43,12 +46,11 @@ class TestRawDataset(unittest.TestCase):
             self.assertEqual(ds[i].shape, expected_shape)
 
     def test_dataset_4d(self):
-        from torch_em.data import RawDataset
         raw_key = "raw"
         shape = (12, 64, 64, 64)
         self.create_default_data(raw_key, shape=shape)
         patch_shape = (3, 32, 32, 32)
-        ds = RawDataset(self.path, raw_key, patch_shape=patch_shape)
+        ds = self.dataset_class(self.path, raw_key, patch_shape=patch_shape)
         self.assertEqual(ds.raw.shape, shape)
         self.assertEqual(ds._ndim, 4)
         expected_shape = patch_shape
@@ -56,12 +58,11 @@ class TestRawDataset(unittest.TestCase):
             self.assertEqual(ds[i].shape, expected_shape)
 
     def test_roi(self):
-        from torch_em.data import RawDataset
         raw_key = "raw"
         self.create_default_data(raw_key)
         patch_shape = (32, 32, 32)
         roi = np.s_[32:96, 32:96, 32:96]
-        ds = RawDataset(self.path, raw_key, patch_shape=patch_shape, roi=roi)
+        ds = self.dataset_class(self.path, raw_key, patch_shape=patch_shape, roi=roi)
         roi_shape = 3 * (64,)
         self.assertEqual(ds.raw.shape, roi_shape)
         expected_shape = (1,) + patch_shape
@@ -69,35 +70,102 @@ class TestRawDataset(unittest.TestCase):
             self.assertEqual(tuple(ds[i].shape), expected_shape)
 
     def test_with_channels(self):
-        from torch_em.data import RawDataset
         raw_key = "raw"
         self.create_default_data(raw_key, shape=(3, 128, 128, 128), chunks=(1, 32, 32, 32))
         patch_shape = (32, 32, 32)
-        ds = RawDataset(self.path, raw_key, patch_shape=patch_shape, ndim=3, with_channels=True)
+        ds = self.dataset_class(self.path, raw_key, patch_shape=patch_shape, ndim=3, with_channels=True)
         self.assertEqual(ds._ndim, 3)
         expected_raw_shape = (3,) + patch_shape
         for i in range(10):
             self.assertEqual(ds[i].shape, expected_raw_shape)
 
-class TestRawDatasetWithMasks(unittest.TestCase):
-    path = "./data.h5"
 
+class TestRawDataset(TestRawDatasetBase, unittest.TestCase):
+    dataset_class = RawDataset
+
+
+class TestRawDatasetWithMasks(TestRawDatasetBase, unittest.TestCase):
+    dataset_class = RawDatasetWithMasks
+    mrc_path = "./mask.mrc"
+    
     def tearDown(self):
-        os.remove(self.path)
+        super().tearDown()
 
-    def create_default_data(self, key, shape=None, chunks=None):
-        shape = (128,) * 3 if shape is None else shape
-        chunks = tuple(min(32, sh) for sh in shape) if chunks is None else chunks
-        with h5py.File(self.path, "a") as f:
-            f.create_dataset(key, data=np.random.rand(*shape), chunks=chunks)
-        return shape, chunks
+        if os.path.exists(self.mrc_path):
+            os.remove(self.mrc_path)
+    
+    def create_default_mrc_data(self, data):
+        import mrcfile
+        with mrcfile.new(self.mrc_path, overwrite=True) as f:
+            f.set_data(data.astype(np.float32))
 
+    # subclass-specific tests, designed for a 3d dataset
     def test_sample_mask(self):
-        from torch_em.data import RawDatasetWithMasks
+        from torch_em.data.sampler import MinForegroundSampler
+
+        raw_key, mask_key = "raw", "mask"
+        shape = (128, 128, 128)
+        chunks = (32, 32, 32)
+        
+        # define central z slices 40:80 as the sample ROI, above and below is empty
+        sample_mask = np.zeros(shape, dtype=np.float32)
+        sample_mask[40:80, :, :] = 1.0
+
+        with h5py.File(self.path, "a") as f:
+            f.create_dataset(raw_key, data=sample_mask, chunks=chunks)
+            f.create_dataset(mask_key, data=sample_mask, chunks=chunks)
+
+        patch_shape = chunks
+
+        min_fraction = 0.95
+        sampler = MinForegroundSampler(min_fraction=min_fraction)
+
+        ds = self.dataset_class(self.path, raw_key, patch_shape=patch_shape, sampler=sampler, 
+                                sample_mask_path=self.path, sample_mask_key=mask_key)
+
+        self.assertEqual(ds.raw.shape, shape)
+        self.assertEqual(ds.sample_mask.shape, shape)
+        self.assertEqual(ds._ndim, 3)
+
+        expected_shape = (1,) + patch_shape
+        for i in range(10):
+            patch = ds[i]
+            self.assertEqual(patch.shape, expected_shape)
+
+            # check that patches are sampled inside the ROI defined by sample mask
+            self.assertGreaterEqual(patch.mean().item(), min_fraction)
 
     def test_bg_mask(self):
-        from torch_em.data import RawDatasetWithMasks
+        raw_key, mask_key = "raw", "mask"
 
+        shape, chunks = self.create_default_data(raw_key)
+        self.create_default_data(mask_key)
 
+        patch_shape = chunks
+        ds = self.dataset_class(self.path, raw_key, patch_shape=patch_shape, 
+                                bg_mask_path=self.path, bg_mask_key=mask_key)
+
+        self.assertEqual(ds.raw.shape, shape)
+        self.assertEqual(ds.bg_mask.shape, shape)
+        self.assertEqual(ds._ndim, 3)
+        expected_shape = (2,) + patch_shape
+
+        for i in range(10):
+
+            patch = ds[i]
+            self.assertEqual(patch.shape, expected_shape)
+
+    def test_bg_mask_mrc(self):
+        raw_key, mask_key = "raw", None
+
+        shape, chunks = self.create_default_data(raw_key)
+        self.create_default_mrc_data(np.zeros(shape))
+
+        patch_shape = chunks
+        ds = self.dataset_class(self.path, raw_key, patch_shape=patch_shape, 
+                                bg_mask_path=self.mrc_path, bg_mask_key=None)
+        
+        self.assertEqual(ds.bg_mask.shape, shape)
+        
 if __name__ == "__main__":
     unittest.main()

--- a/test/data/test_raw_dataset.py
+++ b/test/data/test_raw_dataset.py
@@ -79,6 +79,25 @@ class TestRawDataset(unittest.TestCase):
         for i in range(10):
             self.assertEqual(ds[i].shape, expected_raw_shape)
 
+class TestRawDatasetWithMasks(unittest.TestCase):
+    path = "./data.h5"
+
+    def tearDown(self):
+        os.remove(self.path)
+
+    def create_default_data(self, key, shape=None, chunks=None):
+        shape = (128,) * 3 if shape is None else shape
+        chunks = tuple(min(32, sh) for sh in shape) if chunks is None else chunks
+        with h5py.File(self.path, "a") as f:
+            f.create_dataset(key, data=np.random.rand(*shape), chunks=chunks)
+        return shape, chunks
+
+    def test_sample_mask(self):
+        from torch_em.data import RawDatasetWithMasks
+
+    def test_bg_mask(self):
+        from torch_em.data import RawDatasetWithMasks
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/torch_em/data/__init__.py
+++ b/torch_em/data/__init__.py
@@ -3,7 +3,7 @@
 from .concat_dataset import ConcatDataset
 from .dataset_wrapper import DatasetWrapper
 from .image_collection_dataset import ImageCollectionDataset
-from .raw_dataset import RawDataset
+from .raw_dataset import RawDataset, RawDatasetWithMasks
 from .pseudo_label_dataset import PseudoLabelDataset
 from .raw_image_collection_dataset import RawImageCollectionDataset
 from .segmentation_dataset import SegmentationDataset

--- a/torch_em/data/raw_dataset.py
+++ b/torch_em/data/raw_dataset.py
@@ -199,3 +199,143 @@ class RawDataset(torch.utils.data.Dataset):
             state["raw"] = None
 
         self.__dict__.update(state)
+
+
+class RawDatasetWithMasks(RawDataset):
+    """Dataset that provides raw data stored in a container data format for unsupervised training.
+
+    # TODO update subclass description, news args
+
+    Args:
+        raw_path: The file path to the raw image data. May also be a list of file paths.
+        raw_key: The key to the internal dataset containing the raw data.
+        patch_shape: The patch shape for a training sample.
+        raw_transform: Transformation applied to the raw data of a sample.
+        transform: Transformation to the raw data. This can be used to implement data augmentations.
+        roi: Region of interest in the raw data.
+            If given, the raw data will only be loaded from the corresponding area.
+        dtype: The return data type of the raw data.
+        n_samples: The length of this dataset. If None, the length will be set to `len(raw_image_paths)`.
+        sampler: Sampler for rejecting samples according to a defined criterion.
+            The sampler must be a callable that accepts the raw data (as numpy arrays) as input.
+        ndim: The spatial dimensionality of the data. If None, will be derived from the raw data.
+        with_channels: Whether the raw data has channels.
+        augmentations: Augmentations for contrastive learning. If given, these need to be two different callables.
+            They will be applied to the sampled raw data to return two independent views of the raw data.
+        sample_mask_path: 
+        sample_mask_key: 
+        bg_mask_path: 
+        bg_mask_key: 
+    """
+    
+    def __init__(
+        self,
+        raw_path: Union[List[Any], str, os.PathLike],
+        raw_key: Optional[str],
+        patch_shape: Tuple[int, ...],
+        raw_transform: Optional[Callable] = None,
+        transform: Optional[Callable] = None,
+        roi: Optional[Union[slice, Tuple[slice, ...]]] = None,
+        dtype: torch.dtype = torch.float32,
+        n_samples: Optional[int] = None,
+        sampler: Optional[Callable] = None,
+        ndim: Optional[int] = None,
+        with_channels: bool = False,
+        augmentations: Optional[Tuple[Callable, Callable]] = None,
+        sample_mask_path: Union[List[Any], str, os.PathLike] = None,
+        sample_mask_key: Optional[str] = None,
+        bg_mask_path: Union[List[Any], str, os.PathLike] = None,
+        bg_mask_key: Optional[str] = None,
+    ):
+        super(RawDataset, self).__init__()
+        # enforce that keys are set to "data" when no key is provided; this allows `load_data` to load mrc files
+        if sample_mask_path is not None and sample_mask_key is None:
+            sample_mask_key = "data"
+        if bg_mask_path is not None and bg_mask_key is None:
+            bg_mask_key = "data"
+
+        self.sample_mask_path = sample_mask_path
+        self.sample_mask_key = sample_mask_key
+        self.sample_mask = load_data(sample_mask_path, sample_mask_key) if sample_mask_path is not None else None
+
+        self.bg_mask_path = bg_mask_path
+        self.bg_mask_key = bg_mask_key
+        self.bg_mask = load_data(bg_mask_path, bg_mask_key) if bg_mask_path is not None else None
+
+    # TOOD should this handle with_channels? feels like unnecessary complexity
+    def _get_sample(self, index): #TODO update `_get_sample`
+        if self.raw is None:
+            raise RuntimeError("RawDataset has not been properly deserialized.")
+        # TODO remove duplicate logic?
+        bb = self._sample_bounding_box()
+        raw = self.raw[(slice(None),) + bb] if self._with_channels else self.raw[bb]
+        
+
+        if self.sampler is not None:
+            sample_id = 0
+            if self.sample_mask is not None:
+                while not self.sampler(raw, sample_mask):
+                    bb = self._sample_bounding_box()
+                    raw = self.raw[(slice(None),) + bb] if self._with_channels else self.raw[bb]
+                    sample_mask = self.sample_mask[(slice(None),) + bb] if self._with_channels else self.sample_mask[bb]
+                    sample_id += 1
+                    if sample_id > self.max_sampling_attempts:
+                        raise RuntimeError(f"Could not sample a valid batch in {self.max_sampling_attempts} attempts")
+            else:
+                while not self.sampler(raw):
+                    bb = self._sample_bounding_box()
+                    raw = self.raw[(slice(None),) + bb] if self._with_channels else self.raw[bb]
+                    sample_id += 1
+                    if sample_id > self.max_sampling_attempts:
+                        raise RuntimeError(f"Could not sample a valid batch in {self.max_sampling_attempts} attempts")
+        
+        # TODO also apply to bg_mask?
+        if self.patch_shape is not None:
+            raw = ensure_patch_shape(
+                raw=raw, labels=None, patch_shape=self.patch_shape, have_raw_channels=self._with_channels
+            )
+
+        # squeeze the singleton spatial axis if we have a spatial shape that is larger by one than self._ndim
+        if len(self.patch_shape) == self._ndim + 1:
+            raw = raw.squeeze(1 if self._with_channels else 0)
+
+        return raw, bb
+    
+    # TODO update get_item
+    def __getitem__(self, index):
+        raw, bb = self._get_sample(index)
+
+        if self.raw_transform is not None:
+            raw = self.raw_transform(raw)
+
+        if self.transform is not None:
+            raw = self.transform(raw)
+            if isinstance(raw, list):
+                assert len(raw) == 1
+                raw = raw[0]
+
+            if self.trafo_halo is not None:
+                raw = self.crop(raw)
+
+        raw = ensure_tensor_with_channels(raw, ndim=self._ndim, dtype=self.dtype)
+        if self.augmentations is not None:
+            aug1, aug2 = self.augmentations
+            raw1, raw2 = aug1(raw), aug2(raw)
+            return raw1, raw2
+
+        # extract the background mask
+        if self.bg_mask is not None:
+            bg_mask = self.bg_mask[(slice(None),) + bb] if self._with_channels else self.bg_mask[bb]
+            
+            # TODO instead use `ensure_patch_shape`
+            if raw.shape != bg_mask.shape:
+
+                raise ValueError(f"Expect raw and background mask of same shape, got: \
+                                 {raw.shape}, {bg_mask.shape}.")
+
+            # if background_mask, returned stacked data
+            return np.stacked(raw, bg_mask, axis=0)
+            
+        # else, return raw
+        return raw
+    

--- a/torch_em/data/raw_dataset.py
+++ b/torch_em/data/raw_dataset.py
@@ -206,7 +206,6 @@ class RawDatasetWithMasks(RawDataset):
 
         - The sample mask is used by the sampler to extract patches from a region of interest, e.g.,
             using `MinForegroundSampler`, to avoid empty patches. 
-
         - The background mask is a binary mask identifying regions or structures that belong to the background. 
             It can be used during unsupervised training to subtract background regions from the predicted
             pseudo labels. 
@@ -279,7 +278,7 @@ class RawDatasetWithMasks(RawDataset):
     def _extract_patch(self, data, bb):
             return data[(slice(None),) + bb] if self._with_channels else data[bb]
     
-    def _get_sample(self, index): #TODO update `_get_sample`
+    def _get_sample(self, index):
         if self.raw is None:
             raise RuntimeError("RawDataset has not been properly deserialized.")
         
@@ -313,8 +312,12 @@ class RawDatasetWithMasks(RawDataset):
         bg_mask = self._extract_patch(self.bg_mask, bb) if self.bg_mask is not None else None
         
         if self.patch_shape is not None:
-            raw, bg_mask = ensure_patch_shape(raw=raw, labels=bg_mask, patch_shape=self.patch_shape,
-                                              have_raw_channels=self._with_channels, have_label_channels=self._with_channels)
+            if bg_mask is not None:
+                raw, bg_mask = ensure_patch_shape(raw=raw, labels=bg_mask, patch_shape=self.patch_shape,
+                                                have_raw_channels=self._with_channels, have_label_channels=self._with_channels)
+            else:
+                raw = ensure_patch_shape(raw=raw, labels=None, patch_shape=self.patch_shape,
+                                                have_raw_channels=self._with_channels, have_label_channels=self._with_channels)
    
         # squeeze the singleton spatial axis if we have a spatial shape that is larger by one than self._ndim
         if len(self.patch_shape) == self._ndim + 1:
@@ -356,6 +359,7 @@ class RawDatasetWithMasks(RawDataset):
             return raw1, raw2
 
         if bg_mask is not None:
+            
             # if background_mask, returned stacked data
             return torch.cat((raw, bg_mask), dim=0)
             

--- a/torch_em/data/raw_dataset.py
+++ b/torch_em/data/raw_dataset.py
@@ -202,9 +202,14 @@ class RawDataset(torch.utils.data.Dataset):
 
 
 class RawDatasetWithMasks(RawDataset):
-    """Dataset that provides raw data stored in a container data format for unsupervised training.
+    """Extends `RawDataset` to support a sample mask and a background mask.
 
-    # TODO update subclass description, news args
+        - The sample mask is used by the sampler to extract patches from a region of interest, e.g.,
+            using `MinForegroundSampler`, to avoid empty patches. 
+
+        - The background mask is a binary mask identifying regions or structures that belong to the background. 
+            It can be used during unsupervised training to subtract background regions from the predicted
+            pseudo labels. 
 
     Args:
         raw_path: The file path to the raw image data. May also be a list of file paths.

--- a/torch_em/data/raw_dataset.py
+++ b/torch_em/data/raw_dataset.py
@@ -262,7 +262,7 @@ class RawDatasetWithMasks(RawDataset):
         self.bg_mask_key = bg_mask_key
         self.bg_mask = load_data(bg_mask_path, bg_mask_key) if bg_mask_path is not None else None
 
-    # TOOD should this handle with_channels? feels like unnecessary complexity
+    # TODO should this handle with_channels? feels like unnecessary complexity
     def _get_sample(self, index): #TODO update `_get_sample`
         if self.raw is None:
             raise RuntimeError("RawDataset has not been properly deserialized.")

--- a/torch_em/data/raw_dataset.py
+++ b/torch_em/data/raw_dataset.py
@@ -222,10 +222,11 @@ class RawDatasetWithMasks(RawDataset):
         with_channels: Whether the raw data has channels.
         augmentations: Augmentations for contrastive learning. If given, these need to be two different callables.
             They will be applied to the sampled raw data to return two independent views of the raw data.
-        sample_mask_path: 
-        sample_mask_key: 
-        bg_mask_path: 
-        bg_mask_key: 
+        sample_mask_path: Filepaths to the sample masks used by the sampler to accept or reject 
+            patches for training.
+        sample_mask_key: The key to the dataset containing the sample masks.
+        bg_mask_path: Filepaths to the background masks, which will be returned together with the raw sample.
+        bg_mask_key: The key to the dataset containing the background masks. 
     """
     
     def __init__(
@@ -247,12 +248,20 @@ class RawDatasetWithMasks(RawDataset):
         bg_mask_path: Union[List[Any], str, os.PathLike] = None,
         bg_mask_key: Optional[str] = None,
     ):
-        super(RawDataset, self).__init__()
-        # enforce that keys are set to "data" when no key is provided; this allows `load_data` to load mrc files
-        if sample_mask_path is not None and sample_mask_key is None:
-            sample_mask_key = "data"
-        if bg_mask_path is not None and bg_mask_key is None:
-            bg_mask_key = "data"
+        super().__init__(
+            raw_path=raw_path,
+            raw_key=raw_key,
+            patch_shape=patch_shape,
+            raw_transform=raw_transform,
+            transform=transform,
+            roi=roi,
+            dtype=dtype,
+            n_samples=n_samples,
+            sampler=sampler,
+            ndim=ndim,
+            with_channels=with_channels,
+            augmentations=augmentations,
+        )
 
         self.sample_mask_path = sample_mask_path
         self.sample_mask_key = sample_mask_key
@@ -262,48 +271,57 @@ class RawDatasetWithMasks(RawDataset):
         self.bg_mask_key = bg_mask_key
         self.bg_mask = load_data(bg_mask_path, bg_mask_key) if bg_mask_path is not None else None
 
-    # TODO should this handle with_channels? feels like unnecessary complexity
+    def _extract_patch(self, data, bb):
+            return data[(slice(None),) + bb] if self._with_channels else data[bb]
+    
     def _get_sample(self, index): #TODO update `_get_sample`
         if self.raw is None:
             raise RuntimeError("RawDataset has not been properly deserialized.")
-        # TODO remove duplicate logic?
+        
+        # default behavior; use if sampler is None
         bb = self._sample_bounding_box()
-        raw = self.raw[(slice(None),) + bb] if self._with_channels else self.raw[bb]
+        raw = self._extract_patch(self.raw, bb)
         
 
         if self.sampler is not None:
             sample_id = 0
             if self.sample_mask is not None:
+                sample_mask = self._extract_patch(self.sample_mask, bb)
+
                 while not self.sampler(raw, sample_mask):
                     bb = self._sample_bounding_box()
-                    raw = self.raw[(slice(None),) + bb] if self._with_channels else self.raw[bb]
-                    sample_mask = self.sample_mask[(slice(None),) + bb] if self._with_channels else self.sample_mask[bb]
+                    raw = self._extract_patch(self.raw, bb)
+                    sample_mask = self._extract_patch(self.sample_mask, bb)
+
                     sample_id += 1
                     if sample_id > self.max_sampling_attempts:
                         raise RuntimeError(f"Could not sample a valid batch in {self.max_sampling_attempts} attempts")
             else:
                 while not self.sampler(raw):
                     bb = self._sample_bounding_box()
-                    raw = self.raw[(slice(None),) + bb] if self._with_channels else self.raw[bb]
+                    raw = self._extract_patch(self.raw, bb)
                     sample_id += 1
                     if sample_id > self.max_sampling_attempts:
                         raise RuntimeError(f"Could not sample a valid batch in {self.max_sampling_attempts} attempts")
         
-        # TODO also apply to bg_mask?
+        
+        bg_mask = self._extract_patch(self.bg_mask, bb) if self.bg_mask is not None else None
+        
         if self.patch_shape is not None:
-            raw = ensure_patch_shape(
-                raw=raw, labels=None, patch_shape=self.patch_shape, have_raw_channels=self._with_channels
-            )
-
+            raw, bg_mask = ensure_patch_shape(raw=raw, labels=bg_mask, patch_shape=self.patch_shape,
+                                              have_raw_channels=self._with_channels, have_label_channels=self._with_channels)
+   
         # squeeze the singleton spatial axis if we have a spatial shape that is larger by one than self._ndim
         if len(self.patch_shape) == self._ndim + 1:
             raw = raw.squeeze(1 if self._with_channels else 0)
 
-        return raw, bb
+            if bg_mask is not None:
+                bg_mask = bg_mask.squeeze(1 if self._with_channels else 0)
+
+        return raw, bg_mask
     
-    # TODO update get_item
     def __getitem__(self, index):
-        raw, bb = self._get_sample(index)
+        raw, bg_mask = self._get_sample(index)
 
         if self.raw_transform is not None:
             raw = self.raw_transform(raw)
@@ -318,23 +336,23 @@ class RawDatasetWithMasks(RawDataset):
                 raw = self.crop(raw)
 
         raw = ensure_tensor_with_channels(raw, ndim=self._ndim, dtype=self.dtype)
+        bg_mask = ensure_tensor_with_channels(bg_mask, ndim=self._ndim, dtype=self.dtype) if bg_mask is not None else None
+
         if self.augmentations is not None:
             aug1, aug2 = self.augmentations
             raw1, raw2 = aug1(raw), aug2(raw)
+
+            if bg_mask is not None:
+
+                # if background_mask, returned stacked data
+                return torch.cat((raw1, bg_mask), dim=0), torch.cat((raw2, bg_mask), dim=0)
+            
+            # else, return augmented raw
             return raw1, raw2
 
-        # extract the background mask
-        if self.bg_mask is not None:
-            bg_mask = self.bg_mask[(slice(None),) + bb] if self._with_channels else self.bg_mask[bb]
-            
-            # TODO instead use `ensure_patch_shape`
-            if raw.shape != bg_mask.shape:
-
-                raise ValueError(f"Expect raw and background mask of same shape, got: \
-                                 {raw.shape}, {bg_mask.shape}.")
-
+        if bg_mask is not None:
             # if background_mask, returned stacked data
-            return np.stacked(raw, bg_mask, axis=0)
+            return torch.cat((raw, bg_mask), dim=0)
             
         # else, return raw
         return raw

--- a/torch_em/data/raw_dataset.py
+++ b/torch_em/data/raw_dataset.py
@@ -365,4 +365,18 @@ class RawDatasetWithMasks(RawDataset):
             
         # else, return raw
         return raw
-    
+
+    def __getstate__(self):
+        state = super().__getstate__()
+        del state["sample_mask"]
+        del state["bg_mask"]
+        return state
+
+    def __setstate__(self, state):
+        super().__setstate__(state)
+        sample_mask_path = state.get("sample_mask_path")
+        sample_mask_key = state.get("sample_mask_key")
+        bg_mask_path = state.get("bg_mask_path")
+        bg_mask_key = state.get("bg_mask_key")
+        self.sample_mask = load_data(sample_mask_path, sample_mask_key) if sample_mask_path is not None else None
+        self.bg_mask = load_data(bg_mask_path, bg_mask_key) if bg_mask_path is not None else None

--- a/torch_em/util/image.py
+++ b/torch_em/util/image.py
@@ -90,6 +90,15 @@ def load_data(
     have_single_file = isinstance(path, str)
     have_single_key = isinstance(key, str)
 
+    # mrc files require key="data"; set it automatically if no key was provided
+    if key is None:
+        if have_single_file and str(path).endswith(".mrc"):
+            key = "data"
+            have_single_key = True
+        elif not have_single_file and all(str(p).endswith(".mrc") for p in path):
+            key = "data"
+            have_single_key = True
+
     if key is None:
         if have_single_file:
             return load_image(path)


### PR DESCRIPTION
new subclass `RawDatasetWithMasks` handles:
- sample mask for sampling patches; intended for use with `MinForegroundSampler`
- background mask for subtracting background from the loss

changes
- new args `sample_mask`, `sample_mask_key`, `bg_mask`, `bg_mask_key`
- `_get_sample` - returns raw and a bb, which are needed to ensure the correct patch is extracted from `bg_mask`, if present
-  `_get_item` - if `bg_mask` is present, returns a stacked array (expected format) for `MeanTeacherTrainerWithBackgroundMask`

to do
- update documentation
- write tests
