### PR TITLE
Minor update to cremi dataset

### DIFF
--- a/torch_em/data/datasets/electron_microscopy/cremi.py
+++ b/torch_em/data/datasets/electron_microscopy/cremi.py
@@ -144,7 +144,9 @@ def get_cremi_dataset(
 
     # defect augmentations
     if defect_augmentation_kwargs is not None:
+        from torch_em.transform.raw import standardize
         raw_transform = torch_em.transform.get_raw_transform(
+            normalizer=kwargs.pop("raw_transform", standardize),
             augmentation1=torch_em.transform.EMDefectAugmentation(**defect_augmentation_kwargs)
         )
         kwargs = util.update_kwargs(kwargs, "raw_transform", raw_transform)

--- a/torch_em/data/datasets/electron_microscopy/cremi.py
+++ b/torch_em/data/datasets/electron_microscopy/cremi.py
@@ -7,6 +7,7 @@ Please cite the challenge if you use the dataset in your research.
 # TODO add support for realigned volumes
 
 import os
+import warnings
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -16,6 +17,7 @@ from torch.utils.data import Dataset, DataLoader
 import torch_em
 
 from .. import util
+from ....transform.raw import standardize
 
 
 CREMI_URLS = {
@@ -144,7 +146,11 @@ def get_cremi_dataset(
 
     # defect augmentations
     if defect_augmentation_kwargs is not None:
-        from torch_em.transform.raw import standardize
+        if "raw_transform" in kwargs:
+            warnings.warn(
+                "'raw_transform' was found in kwargs. It will be used as the "
+                "normalizer for the defect augmentation pipeline."
+            )
         raw_transform = torch_em.transform.get_raw_transform(
             normalizer=kwargs.pop("raw_transform", standardize),
             augmentation1=torch_em.transform.EMDefectAugmentation(**defect_augmentation_kwargs)

--- a/torch_em/data/datasets/electron_microscopy/cremi.py
+++ b/torch_em/data/datasets/electron_microscopy/cremi.py
@@ -149,7 +149,8 @@ def get_cremi_dataset(
         if "raw_transform" in kwargs:
             warnings.warn(
                 "'raw_transform' was found in kwargs. It will be used as the "
-                "normalizer for the defect augmentation pipeline."
+                "normalizer for the defect augmentation pipeline, which may lead to incorrect results"
+                "if the normalizer maps to an unexpected data range."
             )
         raw_transform = torch_em.transform.get_raw_transform(
             normalizer=kwargs.pop("raw_transform", standardize),

--- a/torch_em/transform/defect.py
+++ b/torch_em/transform/defect.py
@@ -43,7 +43,7 @@ class EMDefectAugmentation:
     Args:
         p_drop_slice: Probability for a missing slice.
         p_low_contrast: Probability for a low contrast slice.
-        p_deform_slice: Probaboloty for a deformed slice.
+        p_deform_slice: Probability for a deformed slice.
         p_paste_artifact: Probability for inserting an artifact from data source.
         contrast_scale: Scale of low contrast transformation.
         deformation_mode: Deformation mode that should be used.


### PR DESCRIPTION
Hi @constantinpape,

Okay this PR is a bit of a tricky one, but lemme explain:

When `defect_augmentation_kwargs` are used (which is necessary for CREMI to dodge data-level artifacts), it utilizes the `raw_transform` inside the `get_cremi_dataset` and ignores `raw_transform` as input from user completely (which is exactly how it should be). Now, I would like to keep the data statistics to 8 bit (i.e. standardized by `torch_em.transform.get_raw_transform`). For this, I allow users to pass `raw_transform` too, such that it acts as a normalization protocol on top of `defect_augmentation_kwargs`, when applied.

What do you think about this change?