### PR TITLE
Fix dataset issues

### DIFF
--- a/torch_em/data/datasets/electron_microscopy/fafb_nuclei.py
+++ b/torch_em/data/datasets/electron_microscopy/fafb_nuclei.py
@@ -1,6 +1,6 @@
 """This dataset contains crops of EM data with annotated nuclei from the adult fruit fly brain.
 
-The data is extracted from https://doi.org/10.1101/2021.11.04.46719, which contains a segmentation
+The data is extracted from https://doi.org/10.1101/2021.11.04.467197, which contains a segmentation
 of all nuclei in the fruit fly brain. Please cite it if you use this dataset for a publication.
 """
 

--- a/torch_em/data/datasets/electron_microscopy/mitoemv2.py
+++ b/torch_em/data/datasets/electron_microscopy/mitoemv2.py
@@ -102,6 +102,10 @@ def _preprocess_dataset(path, dataset_name, dataset_dir):
                     raw = f_raw["data"][:]
                 with z5py.File(os.path.join(n5_dir, f"{sample}_labels.n5"), "r") as f_lbl:
                     labels = f_lbl["data"][:]
+                
+                if sample == "me2-jurkat_train02":
+                    print("Label dimensions in nifti are stored the other way around for this sample, transposing labels...")
+                    labels = np.transpose(labels, (2, 1, 0))
 
                 with z5py.File(n5_path, "a") as f:
                     f.create_dataset("raw", data=raw, chunks=(32, 256, 256), compression="gzip")


### PR DESCRIPTION
- fix data doi for fafb nuclei
- corrected data loading for mito em 2 dataset me2-jurkat_train02: label dimensions in nifti are stored the other way around for this sample, transposing labels