### PR TITLE
Handle dataLoaders without explicit shuffle attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ logs/
 *.pt
 *.DS_Store
 .claude/
+.codex

--- a/test/trainer/test_default_trainer.py
+++ b/test/trainer/test_default_trainer.py
@@ -30,14 +30,26 @@ class TestDefaultTrainer(unittest.TestCase):
         rmtree(self.checkpoint_folder, ignore_errors=True)
         rmtree(self.log_folder, ignore_errors=True)
 
-    def _get_kwargs(self, with_roi=False, compile_model=False):
+    def _get_loader(self, with_roi=False, external=False):
         roi = np.s_[:6, :, :] if with_roi else None
-        loader = torch_em.default_segmentation_loader(
-            raw_paths=self.data_path, raw_key="raw",
-            label_paths=self.data_path, label_key="labels",
-            batch_size=1, patch_shape=(1, 128, 128), ndim=2,
-            rois=roi,
-        )
+        if external:
+            ds = torch_em.default_segmentation_dataset(
+                raw_paths=self.data_path, raw_key="raw",
+                label_paths=self.data_path, label_key="labels",
+                patch_shape=(1, 128, 128), ndim=2,
+                rois=roi,
+            )
+            return torch.utils.data.DataLoader(ds, batch_size=1, shuffle=True)
+        else:
+            return torch_em.default_segmentation_loader(
+                raw_paths=self.data_path, raw_key="raw",
+                label_paths=self.data_path, label_key="labels",
+                batch_size=1, patch_shape=(1, 128, 128), ndim=2,
+                rois=roi,
+            )
+
+    def _get_kwargs(self, with_roi=False, compile_model=False, external=False):
+        loader = self._get_loader(with_roi=with_roi, external=external)
         model = UNet2d(in_channels=1, out_channels=1,
                        depth=2, initial_features=4)
         kwargs = {
@@ -102,6 +114,28 @@ class TestDefaultTrainer(unittest.TestCase):
 
         trainer2.fit(10)
         self.assertEqual(trainer2.iteration, 20)
+
+    def test_from_checkpoint_external_dataloader(self):
+        from torch_em.trainer import DefaultTrainer
+
+        trainer = DefaultTrainer(**self._get_kwargs(with_roi=True, external=True))
+        self.assertFalse(hasattr(trainer.train_loader, "shuffle"))
+        self.assertFalse(hasattr(trainer.val_loader, "shuffle"))
+        trainer.fit(4)
+        exp_model = trainer.model
+        exp_data_shape = trainer.train_loader.dataset.raw.shape
+
+        trainer2 = DefaultTrainer.from_checkpoint(
+            os.path.join(self.checkpoint_folder, self.name),
+            name="latest"
+        )
+        self.assertEqual(trainer.iteration, trainer2.iteration)
+        self.assertEqual(trainer2.train_loader.dataset.raw.shape, exp_data_shape)
+        self.assertTrue(torch_em.util.model_is_equal(exp_model, trainer2.model))
+        self.assertTrue(hasattr(trainer2.train_loader, "shuffle"))
+        self.assertTrue(hasattr(trainer2.val_loader, "shuffle"))
+        self.assertTrue(trainer2.train_loader.shuffle)
+        self.assertTrue(trainer2.val_loader.shuffle)
 
     @unittest.skipIf(sys.version_info.minor > 10, "Not supported for python > 3.10")
     def test_compiled_model(self):

--- a/torch_em/trainer/default_trainer.py
+++ b/torch_em/trainer/default_trainer.py
@@ -105,8 +105,6 @@ class DefaultTrainer:
         if name is None and not issubclass(logger, WandbLogger):
             raise TypeError("Name cannot be None if not using the WandbLogger")
 
-        if not all(hasattr(loader, "shuffle") for loader in [train_loader, val_loader]):
-            raise ValueError(f"{self.__class__} requires each dataloader to have 'shuffle' attribute.")
 
         self._generate_name = name is None
         self.name = name

--- a/torch_em/util/util.py
+++ b/torch_em/util/util.py
@@ -285,11 +285,29 @@ def get_constructor_arguments(obj):
 
     # recover the arguments for torch dataloader
     elif isinstance(obj, torch.utils.data.DataLoader):
+        # These are all the "simple" arguements.
+        # "sampler", "batch_sampler" and "worker_init_fn" are more complicated
+        # and generally not used in torch_em
         sampler = getattr(obj, "sampler", None)
+        if sampler is not None and not isinstance(
+            sampler,
+            (
+                torch.utils.data.RandomSampler,
+                torch.utils.data.SequentialSampler,
+                torch.utils.data.SubsetRandomSampler,
+            ),
+        ):
+            warnings.warn(
+                f"DataLoader uses sampler {type(sampler).__name__}, but only its effective `shuffle` setting "
+                "is serialized. `DefaultTrainer.from_checkpoint` will recreate the loader without the original "
+                "sampler, so sampling behavior may change."
+            )
         shuffle = getattr(obj, "shuffle", None)
         if shuffle is None:
             shuffle = getattr(sampler, "shuffle", None)
         if shuffle is None:
+            # Only randomized samplers map to shuffle=True. SequentialSampler is handled
+            # by the default fallback of shuffle=False and does not need a special case.
             shuffle = isinstance(sampler, (torch.utils.data.RandomSampler, torch.utils.data.SubsetRandomSampler))
 
         return {

--- a/torch_em/util/util.py
+++ b/torch_em/util/util.py
@@ -285,15 +285,22 @@ def get_constructor_arguments(obj):
 
     # recover the arguments for torch dataloader
     elif isinstance(obj, torch.utils.data.DataLoader):
-        # These are all the "simple" arguements.
-        # "sampler", "batch_sampler" and "worker_init_fn" are more complicated
-        # and generally not used in torch_em
-        return _get_args(
-            obj, [
-                "batch_size", "shuffle", "num_workers", "pin_memory", "drop_last",
-                "persistent_workers", "prefetch_factor", "timeout"
-            ]
-        )
+        sampler = getattr(obj, "sampler", None)
+        shuffle = getattr(obj, "shuffle", None)
+        if shuffle is None:
+            shuffle = getattr(sampler, "shuffle", None)
+        if shuffle is None:
+            shuffle = isinstance(sampler, (torch.utils.data.RandomSampler, torch.utils.data.SubsetRandomSampler))
+
+        return {
+            **_get_args(
+                obj, [
+                    "batch_size", "num_workers", "pin_memory", "drop_last",
+                    "persistent_workers", "prefetch_factor", "timeout"
+                ]
+            ),
+            "shuffle": shuffle,
+        }
 
     # TODO support common torch losses (e.g. CrossEntropy, BCE)
     warnings.warn(


### PR DESCRIPTION
Hi @constantinpape,

This PR aims to fix #564 (but it's a bit tricky since there's a monkey patch which I'm not familiar with, in terms of the design choice for it).

The `DefaultTrainer` checkpoint serialization previously assumed that every `DataLoader` exposed a `.shuffle` attribute. This breaks for external classical PyTorch dataloaders, even though they are valid inputs for training.

This change keeps the existing `.shuffle` convention for loaders created or restored inside `torch-em`, but infers `shuffle` from the loader sampler when saving constructor arguments. This makes trainer checkpoint save / load work for both `torch-em` dataloaders and external PyTorch dataloaders without requiring users to monkey-patch `.shuffle` themselves (as suggested by the user in the issue above)

What do you think about this?