### PR TITLE
Validate empty ROIs in segmentation dataset

### DIFF
--- a/test/test_segmentation.py
+++ b/test/test_segmentation.py
@@ -166,6 +166,18 @@ class TestSegmentation(unittest.TestCase):
         model_kwargs = dict(in_channels=3, out_channels=1, initial_features=8, depth=3)
         self._test_training(UNet2d, model_kwargs, train_loader, val_loader, n_iterations=51)
 
+    def test_invalid_empty_roi_message(self):
+        from torch_em.segmentation import default_segmentation_loader
+
+        with self.assertRaisesRegex(ValueError, 'Invalid roi .* empty region'):
+            default_segmentation_loader(
+                self.data_path, self.raw_key,
+                self.data_path, self.semantic_label_key,
+                batch_size=1,
+                patch_shape=(1, 64, 64),
+                rois=np.s_[:0, :, :],
+            )
+
     def test_training_with_numpy_data(self):
         from torch_em.segmentation import default_segmentation_loader
         from torch_em.transform import labels_to_binary

--- a/test/test_segmentation.py
+++ b/test/test_segmentation.py
@@ -178,6 +178,22 @@ class TestSegmentation(unittest.TestCase):
                 rois=np.s_[:0, :, :],
             )
 
+    def test_roi_smaller_than_patch_shape(self):
+        from torch_em.segmentation import default_segmentation_loader
+
+        patch_shape = (64, 64, 64)
+        loader = default_segmentation_loader(
+            self.data_path, self.raw_key,
+            self.data_path, self.semantic_label_key,
+            batch_size=1,
+            patch_shape=patch_shape,
+            rois=(slice(0, 10), slice(0, 10), slice(0, 10)),
+        )
+
+        raw, labels = loader.dataset[0]
+        self.assertEqual(raw.shape, (1,) + patch_shape)
+        self.assertEqual(labels.shape, (1,) + patch_shape)
+
     def test_training_with_numpy_data(self):
         from torch_em.segmentation import default_segmentation_loader
         from torch_em.transform import labels_to_binary

--- a/torch_em/data/raw_dataset.py
+++ b/torch_em/data/raw_dataset.py
@@ -7,7 +7,7 @@ import torch
 
 from elf.wrapper import RoiWrapper
 
-from ..util import ensure_tensor_with_channels, ensure_patch_shape, load_data
+from ..util import ensure_tensor_with_channels, ensure_patch_shape, load_data, validate_roi
 
 
 class RawDataset(torch.utils.data.Dataset):
@@ -70,9 +70,8 @@ class RawDataset(torch.utils.data.Dataset):
         self._with_channels = with_channels
 
         if roi is not None:
-            if isinstance(roi, slice):
-                roi = (roi,)
-
+            shape = self.raw.shape[1:] if self._with_channels else self.raw.shape
+            roi = validate_roi(roi, shape, patch_shape)
             self.raw = RoiWrapper(self.raw, (slice(None),) + roi) if self._with_channels else RoiWrapper(self.raw, roi)
 
         self.shape = self.raw.shape[1:] if self._with_channels else self.raw.shape

--- a/torch_em/data/segmentation_dataset.py
+++ b/torch_em/data/segmentation_dataset.py
@@ -9,7 +9,7 @@ import torch
 
 from elf.wrapper import RoiWrapper
 
-from ..util import ensure_spatial_array, ensure_tensor_with_channels, load_data, ensure_patch_shape
+from ..util import ensure_spatial_array, ensure_tensor_with_channels, load_data, ensure_patch_shape, validate_roi
 
 
 class SegmentationDataset(torch.utils.data.Dataset):
@@ -96,9 +96,8 @@ class SegmentationDataset(torch.utils.data.Dataset):
         self._with_label_channels = with_label_channels
 
         if roi is not None:
-            if isinstance(roi, slice):
-                roi = (roi,)
-
+            shape = self.raw.shape[1:] if self._with_channels else self.raw.shape
+            roi = validate_roi(roi, shape, patch_shape)
             self.raw = RoiWrapper(self.raw, (slice(None),) + roi) if self._with_channels else RoiWrapper(self.raw, roi)
             self.labels = RoiWrapper(self.labels, (slice(None),) + roi) if self._with_label_channels else\
                 RoiWrapper(self.labels, roi)

--- a/torch_em/util/__init__.py
+++ b/torch_em/util/__init__.py
@@ -5,7 +5,8 @@ from .reporting import get_training_summary
 from .training import parser_helper
 from .util import (
     auto_compile, ensure_array, ensure_spatial_array, ensure_tensor, ensure_tensor_with_channels,
-    get_constructor_arguments, get_trainer, is_compiled, load_model, model_is_equal, ensure_patch_shape
+    get_constructor_arguments, get_trainer, is_compiled, load_model, model_is_equal, ensure_patch_shape,
+    validate_roi
 )
 
 # NOTE: we don't import the modelzoo convenience functions here.

--- a/torch_em/util/util.py
+++ b/torch_em/util/util.py
@@ -102,6 +102,40 @@ def ensure_tensor(tensor: Union[torch.Tensor, ArrayLike], dtype: Optional[str] =
     return tensor
 
 
+def validate_roi(roi, shape, patch_shape=None):
+    """Normalize an ROI to explicit slices and validate that it is non-empty."""
+    if roi is None:
+        return None
+    if isinstance(roi, slice):
+        roi = (roi,)
+    if not isinstance(roi, tuple):
+        raise TypeError(f"Invalid roi type: {type(roi)}")
+    if len(roi) > len(shape):
+        raise ValueError(f"Invalid roi {roi} for data shape {shape}: too many dimensions")
+
+    normalized_roi = []
+    for this_roi, dim in zip(roi, shape):
+        if not isinstance(this_roi, slice):
+            raise TypeError(f"Invalid roi entry: {this_roi}. Only slices are supported")
+        step = 1 if this_roi.step is None else this_roi.step
+        if step != 1:
+            raise ValueError(f"Invalid roi {roi}: slice steps other than 1 are not supported")
+        start, stop, _ = this_roi.indices(dim)
+        normalized_roi.append(slice(start, stop))
+
+    if len(roi) < len(shape):
+        normalized_roi.extend(slice(0, dim) for dim in shape[len(roi):])
+
+    roi_shape = tuple(sl.stop - sl.start for sl in normalized_roi)
+    if any(sh <= 0 for sh in roi_shape):
+        msg = f"Invalid roi {roi} for data shape {shape}: it results in an empty region"
+        if patch_shape is not None:
+            msg += f" for patch_shape {patch_shape}"
+        raise ValueError(msg)
+
+    return tuple(normalized_roi)
+
+
 def ensure_tensor_with_channels(
     tensor: Union[torch.Tensor, ArrayLike], ndim: int, dtype: Optional[str] = None
 ) -> torch.Tensor:


### PR DESCRIPTION
This should in principle fix #274.

The issue seemed to be that for invalid empty ROIs in `default_segmentation_loader`, it previously failed with a low-level error from `RoiWrapper`, which made the real problem hard to understand.

This PR aims to add validation for ROIs before wrapping the data and raises a clear `ValueError` when the ROI results in an empty region, i.e. for small but non-empty ROIs should still be allowed and continue to work via padding.

What do we think? @lufre1 @constantinpape 