### PR TITLE
Add label path caching for efficient livecell dataloading

### DIFF
--- a/torch_em/data/datasets/light_microscopy/livecell.py
+++ b/torch_em/data/datasets/light_microscopy/livecell.py
@@ -88,10 +88,6 @@ def _annotations_to_instances(coco, image_metadata, category_ids):
     return seg.astype("uint16")
 
 
-def _resolve_cached_paths(cache_dir, paths):
-    return [path if os.path.isabs(path) else os.path.join(cache_dir, path) for path in paths]
-
-
 def _create_segmentations_from_annotations(annotation_file, image_folder, seg_folder, cell_types):
     # Use a per-cell_types cache to avoid reloading the COCO JSON when data is already prepared.
     cache_key = "all" if cell_types is None else "_".join(sorted(cell_types))
@@ -99,9 +95,8 @@ def _create_segmentations_from_annotations(annotation_file, image_folder, seg_fo
     if os.path.exists(cache_file):
         with open(cache_file) as f:
             cached = json.load(f)
-        cache_dir = os.path.dirname(cache_file)
-        image_paths = _resolve_cached_paths(cache_dir, cached["image_paths"])
-        seg_paths = _resolve_cached_paths(cache_dir, cached["seg_paths"])
+        image_paths = [os.path.join(seg_folder, fname) for fname in cached["image_paths"]]
+        seg_paths = [os.path.join(seg_folder, fname) for fname in cached["seg_paths"]]
         return image_paths, seg_paths
 
     if COCO is None:

--- a/torch_em/data/datasets/light_microscopy/livecell.py
+++ b/torch_em/data/datasets/light_microscopy/livecell.py
@@ -6,6 +6,7 @@ Please cite it if you use this dataset in your research.
 """
 
 import os
+import json
 import requests
 from tqdm import tqdm
 from shutil import copyfileobj
@@ -87,7 +88,22 @@ def _annotations_to_instances(coco, image_metadata, category_ids):
     return seg.astype("uint16")
 
 
+def _resolve_cached_paths(cache_dir, paths):
+    return [path if os.path.isabs(path) else os.path.join(cache_dir, path) for path in paths]
+
+
 def _create_segmentations_from_annotations(annotation_file, image_folder, seg_folder, cell_types):
+    # Use a per-cell_types cache to avoid reloading the COCO JSON when data is already prepared.
+    cache_key = "all" if cell_types is None else "_".join(sorted(cell_types))
+    cache_file = os.path.join(seg_folder, f"seg_paths_{cache_key}.json")
+    if os.path.exists(cache_file):
+        with open(cache_file) as f:
+            cached = json.load(f)
+        cache_dir = os.path.dirname(cache_file)
+        image_paths = _resolve_cached_paths(cache_dir, cached["image_paths"])
+        seg_paths = _resolve_cached_paths(cache_dir, cached["seg_paths"])
+        return image_paths, seg_paths
+
     if COCO is None:
         raise ModuleNotFoundError(
             "'pycocotools' is required for processing the LIVECell ground-truth. "
@@ -130,6 +146,12 @@ def _create_segmentations_from_annotations(annotation_file, image_folder, seg_fo
     assert len(image_paths) == len(seg_paths)
     assert len(image_paths) > 0, \
         f"No matching image paths were found. Did you pass invalid cell type names ({cell_types})?"
+
+    cache_dir = os.path.dirname(cache_file)
+    image_paths_rel = [os.path.relpath(image_path, start=cache_dir) for image_path in image_paths]
+    seg_paths_rel = [os.path.relpath(seg_path, start=cache_dir) for seg_path in seg_paths]
+    with open(cache_file, "w") as f:
+        json.dump({"image_paths": image_paths_rel, "seg_paths": seg_paths_rel}, f)
 
     return image_paths, seg_paths
 


### PR DESCRIPTION
Okay this has been annoying me for a while. I decided to take care of it. This makes the label path loading efficient for the livecell data. Otherwise, one has to make the coco-style preparation everytime, and it burns a few minutes before the dataloading works out!

This should work now, and GTM from my side!
