### PR TITLE
Fix flake8 and style violations in torch_em and test

### DIFF
--- a/test/data/test_raw_dataset.py
+++ b/test/data/test_raw_dataset.py
@@ -87,13 +87,13 @@ class TestRawDataset(TestRawDatasetBase, unittest.TestCase):
 class TestRawDatasetWithMasks(TestRawDatasetBase, unittest.TestCase):
     dataset_class = RawDatasetWithMasks
     mrc_path = "./mask.mrc"
-    
+
     def tearDown(self):
         super().tearDown()
 
         if os.path.exists(self.mrc_path):
             os.remove(self.mrc_path)
-    
+
     def create_default_mrc_data(self, data):
         import mrcfile
         with mrcfile.new(self.mrc_path, overwrite=True) as f:
@@ -106,7 +106,7 @@ class TestRawDatasetWithMasks(TestRawDatasetBase, unittest.TestCase):
         raw_key, mask_key = "raw", "mask"
         shape = (128, 128, 128)
         chunks = (32, 32, 32)
-        
+
         # define central z slices 40:80 as the sample ROI, above and below is empty
         sample_mask = np.zeros(shape, dtype=np.float32)
         sample_mask[40:80, :, :] = 1.0
@@ -120,8 +120,10 @@ class TestRawDatasetWithMasks(TestRawDatasetBase, unittest.TestCase):
         min_fraction = 0.95
         sampler = MinForegroundSampler(min_fraction=min_fraction)
 
-        ds = self.dataset_class(self.path, raw_key, patch_shape=patch_shape, sampler=sampler, 
-                                sample_mask_path=self.path, sample_mask_key=mask_key)
+        ds = self.dataset_class(
+            self.path, raw_key, patch_shape=patch_shape, sampler=sampler,
+            sample_mask_path=self.path, sample_mask_key=mask_key,
+        )
 
         self.assertEqual(ds.raw.shape, shape)
         self.assertEqual(ds.sample_mask.shape, shape)
@@ -144,8 +146,9 @@ class TestRawDatasetWithMasks(TestRawDatasetBase, unittest.TestCase):
         self.create_default_data(mask_key)
 
         patch_shape = chunks
-        ds = self.dataset_class(self.path, raw_key, patch_shape=patch_shape, 
-                                bg_mask_path=self.path, bg_mask_key=mask_key)
+        ds = self.dataset_class(
+            self.path, raw_key, patch_shape=patch_shape, bg_mask_path=self.path, bg_mask_key=mask_key,
+        )
 
         self.assertEqual(ds.raw.shape, shape)
         self.assertEqual(ds.bg_mask.shape, shape)
@@ -158,16 +161,18 @@ class TestRawDatasetWithMasks(TestRawDatasetBase, unittest.TestCase):
             self.assertEqual(patch.shape, expected_shape)
 
     def test_bg_mask_mrc(self):
-        raw_key, mask_key = "raw", None
+        raw_key = "raw"
 
         shape, chunks = self.create_default_data(raw_key)
         self.create_default_mrc_data(np.zeros(shape))
 
         patch_shape = chunks
-        ds = self.dataset_class(self.path, raw_key, patch_shape=patch_shape, 
-                                bg_mask_path=self.mrc_path, bg_mask_key=None)
-        
+        ds = self.dataset_class(
+            self.path, raw_key, patch_shape=patch_shape, bg_mask_path=self.mrc_path, bg_mask_key=None,
+        )
+
         self.assertEqual(ds.bg_mask.shape, shape)
-        
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/loss/test_cldice.py
+++ b/test/loss/test_cldice.py
@@ -1,6 +1,7 @@
 import unittest
 import torch
 
+
 class TestclDiceLoss(unittest.TestCase):
     def test_cldice_random(self):
         from torch_em.loss.cldice import CombinedclDiceLoss
@@ -46,7 +47,7 @@ class TestclDiceLoss(unittest.TestCase):
         # 4-pixel wide non-overlapping lines
         x = torch.zeros(*shape)
         x[0, 0, 4:8, :] = 1.0
-        
+
         y = torch.zeros(*shape)
         y[0, 0, 24:28, :] = 1.0
 
@@ -63,6 +64,7 @@ class TestclDiceLoss(unittest.TestCase):
         y = torch.rand(*shape2)
         with self.assertRaises(ValueError):
             loss(x, y)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/loss/test_loss_wrapper.py
+++ b/test/loss/test_loss_wrapper.py
@@ -4,10 +4,7 @@ import torch
 
 class TestLossWrapper(unittest.TestCase):
     def test_ApplyAndRemove_grad_masking(self):
-        from torch_em.loss import ( ApplyAndRemoveMask,
-                                    ApplyMask,
-                                    DiceLoss,
-                                    LossWrapper)
+        from torch_em.loss import ApplyAndRemoveMask, ApplyMask, DiceLoss, LossWrapper
         shape = (1, 1, 128, 128)
         for masking_func in ApplyMask.MASKING_FUNCS:
             transform = ApplyAndRemoveMask(
@@ -35,12 +32,9 @@ class TestLossWrapper(unittest.TestCase):
             self.assertFalse((grad[mask] == 0).all())
             # print((grad[~mask] == 0).sum())
             self.assertTrue((grad[~mask] == 0).all())
-    
+
     def test_MaskIgnoreLabel_grad_masking(self):
-        from torch_em.loss import ( MaskIgnoreLabel,
-                                    ApplyMask,
-                                    DiceLoss,
-                                    LossWrapper)
+        from torch_em.loss import MaskIgnoreLabel, ApplyMask, DiceLoss, LossWrapper
         shape = (1, 1, 128, 128)
         ignore_label = -1
         for masking_func in ApplyMask.MASKING_FUNCS:
@@ -68,9 +62,7 @@ class TestLossWrapper(unittest.TestCase):
             self.assertTrue((grad[mask] == 0).all())
 
     def test_ApplyMask_grad_masking(self):
-        from torch_em.loss import ( ApplyMask,
-                                    DiceLoss,
-                                    LossWrapper)
+        from torch_em.loss import ApplyMask, DiceLoss, LossWrapper
         shape = (1, 1, 128, 128)
         for masking_func in ApplyMask.MASKING_FUNCS:
             transform = ApplyMask(

--- a/test/metric/test_cldice.py
+++ b/test/metric/test_cldice.py
@@ -1,6 +1,7 @@
 import unittest
 import numpy as np
 
+
 class TestclDiceMetric(unittest.TestCase):
 
     def _test_perfect_overlap(self, skeletonize_method):
@@ -8,7 +9,7 @@ class TestclDiceMetric(unittest.TestCase):
 
         shape = (32, 32)
 
-         # 4-pixel wide overlapping lines
+        # 4-pixel wide overlapping lines
         x = np.zeros(shape)
         x[14:18, :] = 1.0
         y = np.zeros(shape)
@@ -30,7 +31,7 @@ class TestclDiceMetric(unittest.TestCase):
 
         score = clDice(x, y, skeletonize_method=skeletonize_method)
         self.assertAlmostEqual(score, 0.0, places=1)
-    
+
     def test_perfect_overlap_skimage(self):
         self._test_perfect_overlap("skimage")
 
@@ -42,6 +43,7 @@ class TestclDiceMetric(unittest.TestCase):
 
     def test_no_overlap_soft(self):
         self._test_no_overlap("soft")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/transform/test_invertible_augmentations.py
+++ b/test/transform/test_invertible_augmentations.py
@@ -80,7 +80,6 @@ class TestInvertibleAugmenter(unittest.TestCase):
 
         self.assertEqual(x.shape, x_aug.shape)
 
-
     def test_flip_only_3d(self):
         geo = AugmentationSequential3D(
             K.RandomHorizontalFlip(p=1.0),

--- a/torch_em/data/datasets/electron_microscopy/asem.py
+++ b/torch_em/data/datasets/electron_microscopy/asem.py
@@ -48,8 +48,8 @@ VOLUMES = {
 
 ORGANELLES = {
     "mito": ["cell_1", "cell_2", "cell_3", "cell_6", "cell_13", "cell_13a"],
-    "golgi": ["cell_1", "cell_2", "cell_3", "cell_6",],
-    "er": ["cell_1", "cell_2", "cell_3", "cell_6",],
+    "golgi": ["cell_1", "cell_2", "cell_3", "cell_6"],
+    "er": ["cell_1", "cell_2", "cell_3", "cell_6"],
     "ccp": ["cell_12", "cell_13"],
     "np": ["cell_13a"],
     "np_bottom": ["cell_13a"]

--- a/torch_em/data/datasets/electron_microscopy/wildenberg.py
+++ b/torch_em/data/datasets/electron_microscopy/wildenberg.py
@@ -107,7 +107,7 @@ def _wildenberg_download_to_zarr(cv, ds, x0g, y0g, z0g, name, swap_xy=False):
                 x1_ = min(x0_ + sx, shape[2])
                 gz0, gz1 = z0g + z0_, z0g + z1_
                 if swap_xy:
-                    # em cv_x=physical_y, cv_y=physical_x: map physical y→cv_x, physical x→cv_y
+                    # em cv_x=physical_y, cv_y=physical_x: map physical y->cv_x, physical x->cv_y
                     gx0, gx1 = y0g + y0_, y0g + y1_
                     gy0, gy1 = x0g + x0_, x0g + x1_
                 else:
@@ -116,8 +116,8 @@ def _wildenberg_download_to_zarr(cv, ds, x0g, y0g, z0g, name, swap_xy=False):
                 tasks.append(((z0_, z1_), (y0_, y1_), (x0_, x1_), (gx0, gx1, gy0, gy1, gz0, gz1)))
 
     target_dtype = np.dtype(ds.dtype)
-    # swap_xy: block axes are (phys_y, phys_x, phys_z) → transpose(2,0,1) → (z,y,x)
-    # normal:  block axes are (phys_x, phys_y, phys_z) → transpose(2,1,0) → (z,y,x)
+    # swap_xy: block axes are (phys_y, phys_x, phys_z) -> transpose(2,0,1) -> (z,y,x)
+    # normal: block axes are (phys_x, phys_y, phys_z) -> transpose(2,1,0) -> (z,y,x)
     transpose_order = (2, 0, 1) if swap_xy else (2, 1, 0)
 
     def worker(item):

--- a/torch_em/data/datasets/light_microscopy/cshaper.py
+++ b/torch_em/data/datasets/light_microscopy/cshaper.py
@@ -103,7 +103,7 @@ def _convert_to_h5(data_dir: str, split: str) -> str:
         seg_dir = os.path.join(sample_dir, "SegCell")
 
         for raw_path in raw_files:
-            # e.g. Sample01_030_rawMemb.nii.gz → Sample01_030
+            # e.g. Sample01_030_rawMemb.nii.gz -> Sample01_030
             basename = os.path.basename(raw_path)
             tp_stem = basename.replace("_rawMemb.nii.gz", "")
             h5_path = os.path.join(h5_dir, f"{tp_stem}.h5")


### PR DESCRIPTION
Brings the core library (`torch_em/`) and test files into compliance with the repo style rules.

## Changes
- Replace Unicode arrows (`→`) with `->` in comments (`wildenberg.py`, `cshaper.py`).
- Drop trailing commas triggering `E231` in `asem.py`.
- Remove trailing/blank-line whitespace, unused imports/locals, and fix blank-line spacing across the affected test modules.
- Reformat paren-aligned continuation lines to the repo convention (single indent, closing paren on its own line).

## Verification
- `flake8 --max-line-length=120` passes on all changed files.
- Edited loss/metric test modules run green (remaining errors in the suite are a pre-existing `bioimage_cpp` environment issue, unrelated to these changes).