### PR TITLE
Support bfloat16 in mixed precision training

### DIFF
--- a/test/trainer/test_default_trainer.py
+++ b/test/trainer/test_default_trainer.py
@@ -137,6 +137,25 @@ class TestDefaultTrainer(unittest.TestCase):
         self.assertTrue(trainer2.train_loader.shuffle)
         self.assertTrue(trainer2.val_loader.shuffle)
 
+    def test_from_checkpoint_mixed_precision_dtype(self):
+        from torch_em.trainer import DefaultTrainer
+
+        kwargs = self._get_kwargs()
+        kwargs["mixed_precision_dtype"] = "bfloat16"
+        trainer = DefaultTrainer(**kwargs)
+        self.assertFalse(trainer.scaler.is_enabled())
+        trainer.fit(4)
+
+        trainer2 = DefaultTrainer.from_checkpoint(
+            os.path.join(self.checkpoint_folder, self.name),
+            name="latest"
+        )
+        self.assertEqual(trainer2.mixed_precision_dtype, "bfloat16")
+        self.assertFalse(trainer2.scaler.is_enabled())
+
+        trainer2.fit(4)
+        self.assertEqual(trainer2.iteration, 8)
+
     @unittest.skipIf(sys.version_info.minor > 10, "Not supported for python > 3.10")
     def test_compiled_model(self):
         from torch_em.trainer import DefaultTrainer

--- a/torch_em/trainer/default_trainer.py
+++ b/torch_em/trainer/default_trainer.py
@@ -72,6 +72,9 @@ class DefaultTrainer:
         lr_scheduler: The learning rate scheduler.
         log_image_interval: The interval for saving images during logging, in training iterations.
         mixed_precision: Whether to train with mixed precision.
+        mixed_precision_dtype: The dtype for the autocast context in mixed precision training.
+            Defaults to torch.float16. Use torch.bfloat16 on GPUs without Tensor Cores to avoid
+            fp16 accumulation overflow in large convolutions (e.g. Conv2d(512, 512, 3×3)).
         early_stopping: The patience for early stopping in epochs. If None, early stopping will not be used.
         logger: The logger class. Will be instantiated for logging.
             By default uses `torch_em.training.tensorboard_logger.TensorboardLogger`.
@@ -94,6 +97,7 @@ class DefaultTrainer:
         lr_scheduler: Optional[torch.optim.lr_scheduler._LRScheduler] = None,
         log_image_interval: int = 100,
         mixed_precision: bool = True,
+        mixed_precision_dtype: torch.dtype = torch.float16,
         early_stopping: Optional[int] = None,
         logger=TensorboardLogger,
         logger_kwargs: Optional[Dict[str, Any]] = None,
@@ -126,10 +130,11 @@ class DefaultTrainer:
         self._best_epoch = 0
 
         self.mixed_precision = mixed_precision
+        self.mixed_precision_dtype = mixed_precision_dtype
         self.early_stopping = early_stopping
         self.train_time = 0.0
 
-        if mixed_precision:
+        if mixed_precision and mixed_precision_dtype == torch.float16:
             self.scaler = torch.GradScaler("cpu" if self.device.type == "cpu" else "cuda")
         else:
             self.scaler = None
@@ -779,10 +784,10 @@ class DefaultTrainer:
         return self._train_epoch_impl(progress, contextlib.nullcontext, self._backprop)
 
     def _train_epoch_mixed(self, progress):
-        return self._train_epoch_impl(
-            progress, partial(torch.autocast, device_type="cpu" if self.device.type == "cpu" else "cuda"),
-            self._backprop_mixed
-        )
+        device_type = "cpu" if self.device.type == "cpu" else "cuda"
+        ctx = partial(torch.autocast, device_type=device_type, dtype=self.mixed_precision_dtype)
+        backprop = self._backprop_mixed if self.scaler is not None else self._backprop
+        return self._train_epoch_impl(progress, ctx, backprop)
 
     def _forward_and_loss(self, x, y):
         pred = self.model(x)
@@ -825,9 +830,9 @@ class DefaultTrainer:
         return self._validate_impl(contextlib.nullcontext)
 
     def _validate_mixed(self):
-        return self._validate_impl(
-            partial(torch.autocast, device_type="cpu" if self.device.type == "cpu" else "cuda")
-        )
+        device_type = "cpu" if self.device.type == "cpu" else "cuda"
+        ctx = partial(torch.autocast, device_type=device_type, dtype=self.mixed_precision_dtype)
+        return self._validate_impl(ctx)
 
     def _validate_impl(self, forward_context):
         self.model.eval()

--- a/torch_em/trainer/default_trainer.py
+++ b/torch_em/trainer/default_trainer.py
@@ -72,9 +72,8 @@ class DefaultTrainer:
         lr_scheduler: The learning rate scheduler.
         log_image_interval: The interval for saving images during logging, in training iterations.
         mixed_precision: Whether to train with mixed precision.
-        mixed_precision_dtype: The dtype for the autocast context in mixed precision training.
-            Defaults to torch.float16. Use torch.bfloat16 on GPUs without Tensor Cores to avoid
-            fp16 accumulation overflow in large convolutions (e.g. Conv2d(512, 512, 3×3)).
+        mixed_precision_dtype: The dtype for autocast in mixed precision training, 'float16' or 'bfloat16'.
+            The default is 'float16' on the GPU and 'bfloat16' on the CPU. Use 'bfloat16' to avoid overflows.
         early_stopping: The patience for early stopping in epochs. If None, early stopping will not be used.
         logger: The logger class. Will be instantiated for logging.
             By default uses `torch_em.training.tensorboard_logger.TensorboardLogger`.
@@ -97,7 +96,7 @@ class DefaultTrainer:
         lr_scheduler: Optional[torch.optim.lr_scheduler._LRScheduler] = None,
         log_image_interval: int = 100,
         mixed_precision: bool = True,
-        mixed_precision_dtype: torch.dtype = torch.float16,
+        mixed_precision_dtype: Optional[str] = None,
         early_stopping: Optional[int] = None,
         logger=TensorboardLogger,
         logger_kwargs: Optional[Dict[str, Any]] = None,
@@ -124,18 +123,21 @@ class DefaultTrainer:
         self.save_root = save_root
         self.compile_model = compile_model
         self.rank = rank
+        self._device_type = "cpu" if self.device.type == "cpu" else "cuda"
 
         self._iteration = 0
         self._epoch = 0
         self._best_epoch = 0
 
         self.mixed_precision = mixed_precision
-        self.mixed_precision_dtype = mixed_precision_dtype
+        # These are the defaults of torch.autocast for each device type.
+        self.mixed_precision_dtype = mixed_precision_dtype or ("bfloat16" if self._device_type == "cpu" else "float16")
         self.early_stopping = early_stopping
         self.train_time = 0.0
 
-        if mixed_precision and mixed_precision_dtype == torch.float16:
-            self.scaler = torch.GradScaler("cpu" if self.device.type == "cpu" else "cuda")
+        if mixed_precision:
+            # Only float16 needs gradient scaling. bfloat16 has the same range as float32.
+            self.scaler = torch.GradScaler(self._device_type, enabled=self.mixed_precision_dtype == "float16")
         else:
             self.scaler = None
 
@@ -784,10 +786,11 @@ class DefaultTrainer:
         return self._train_epoch_impl(progress, contextlib.nullcontext, self._backprop)
 
     def _train_epoch_mixed(self, progress):
-        device_type = "cpu" if self.device.type == "cpu" else "cuda"
-        ctx = partial(torch.autocast, device_type=device_type, dtype=self.mixed_precision_dtype)
-        backprop = self._backprop_mixed if self.scaler is not None else self._backprop
-        return self._train_epoch_impl(progress, ctx, backprop)
+        return self._train_epoch_impl(
+            progress,
+            partial(torch.autocast, device_type=self._device_type, dtype=getattr(torch, self.mixed_precision_dtype)),
+            self._backprop_mixed
+        )
 
     def _forward_and_loss(self, x, y):
         pred = self.model(x)
@@ -830,9 +833,9 @@ class DefaultTrainer:
         return self._validate_impl(contextlib.nullcontext)
 
     def _validate_mixed(self):
-        device_type = "cpu" if self.device.type == "cpu" else "cuda"
-        ctx = partial(torch.autocast, device_type=device_type, dtype=self.mixed_precision_dtype)
-        return self._validate_impl(ctx)
+        return self._validate_impl(
+            partial(torch.autocast, device_type=self._device_type, dtype=getattr(torch, self.mixed_precision_dtype))
+        )
 
     def _validate_impl(self, forward_context):
         self.model.eval()


### PR DESCRIPTION
The PRs mentioned in the [issue](https://github.com/computational-cell-analytics/micro-sam/issues/1214)

Allows callers to select the autocast dtype for mixed precision training instead of the hardcoded torch.float16. Defaults to torch.float16 to preserve existing behaviour.

- Add `mixed_precision_dtype: torch.dtype = torch.float16` parameter to `DefaultTrainer.__init__` with corresponding docstring entry
- Store `self.mixed_precision_dtype` as an instance attribute so the Serializer can round-trip it through checkpoints
- Create GradScaler only when dtype is float16; bfloat16 has fp32 range and does not require gradient scaling
- Pass `dtype=self.mixed_precision_dtype` to the autocast context in `_train_epoch_mixed` and `_validate_mixed`
- Select `_backprop` (no scaler) vs `_backprop_mixed` (with scaler) based on whether `self.scaler` is None, driven by the chosen dtype