### PR TITLE
Add intensity clipping and custom aug_dict support to invertible augmentations

### DIFF
--- a/torch_em/transform/invertible_augmentations.py
+++ b/torch_em/transform/invertible_augmentations.py
@@ -129,19 +129,21 @@ class InvertibleAugmenter(torch.nn.Module):
         self,
         intensity_transforms: Callable[[torch.Tensor], torch.Tensor],
         geometrical_transforms: Callable[[torch.Tensor], torch.Tensor],
+        clip_max = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self.intensity_transforms = intensity_transforms
         self.geometrical_transforms = geometrical_transforms
+        self.clip_max = clip_max
 
     def reset(self):
         self.params = None
 
     def transform(self, x: torch.Tensor) -> torch.Tensor:
-        clip_max = 255.0 if x.max() > 1.0 else 1.0
         x = self.intensity_transforms(x)
-        x = torch.clamp(x, 0.0, clip_max)
+        if self.clip_max is not None:
+            x = torch.clamp(x, 0.0, self.clip_max)
         x = self.geometrical_transforms(x)
 
         self.params = self.geometrical_transforms._params
@@ -159,9 +161,10 @@ class MeanTeacherAugmenters:
         ndim: int,
         teacher=None,
         student=None,
+        clip_max=None,
     ):
-        self.teacher = teacher or InvertibleAugmenter(*get_augmentations("weak", ndim=ndim))
-        self.student = student or InvertibleAugmenter(*get_augmentations("weak", ndim=ndim))
+        self.teacher = teacher or InvertibleAugmenter(*get_augmentations("weak", ndim=ndim), clip_max=clip_max)
+        self.student = student or InvertibleAugmenter(*get_augmentations("weak", ndim=ndim), clip_max=clip_max)
 
     def reset_all(self):
         self.teacher.reset()
@@ -174,9 +177,10 @@ class FixMatchAugmenters:
         ndim: int,
         teacher=None,
         student=None,
+        clip_max=None,
     ):
-        self.teacher = teacher or InvertibleAugmenter(*get_augmentations("weak", ndim=ndim))
-        self.student = student or InvertibleAugmenter(*get_augmentations("strong", ndim=ndim))
+        self.teacher = teacher or InvertibleAugmenter(*get_augmentations("weak", ndim=ndim), clip_max=clip_max)
+        self.student = student or InvertibleAugmenter(*get_augmentations("strong", ndim=ndim), clip_max=clip_max)
 
     def reset_all(self):
         self.teacher.reset()
@@ -190,10 +194,11 @@ class UniMatchv2Augmenters:
         weak=None,
         strong1=None,
         strong2=None,
+        clip_max=None,
     ):
-        self.weak = weak or InvertibleAugmenter(*get_augmentations("weak", ndim=ndim))
-        self.strong1 = strong1 or InvertibleAugmenter(*get_augmentations("strong", ndim=ndim))
-        self.strong2 = strong2 or InvertibleAugmenter(*get_augmentations("strong", ndim=ndim))
+        self.weak = weak or InvertibleAugmenter(*get_augmentations("weak", ndim=ndim), clip_max=clip_max)
+        self.strong1 = strong1 or InvertibleAugmenter(*get_augmentations("strong", ndim=ndim), clip_max=clip_max)
+        self.strong2 = strong2 or InvertibleAugmenter(*get_augmentations("strong", ndim=ndim), clip_max=clip_max)
 
     def reset_all(self):
         self.weak.reset()

--- a/torch_em/transform/invertible_augmentations.py
+++ b/torch_em/transform/invertible_augmentations.py
@@ -139,7 +139,9 @@ class InvertibleAugmenter(torch.nn.Module):
         self.params = None
 
     def transform(self, x: torch.Tensor) -> torch.Tensor:
+        clip_max = 255.0 if x.max() > 1.0 else 1.0
         x = self.intensity_transforms(x)
+        x = torch.clamp(x, 0.0, clip_max)
         x = self.geometrical_transforms(x)
 
         self.params = self.geometrical_transforms._params

--- a/torch_em/transform/invertible_augmentations.py
+++ b/torch_em/transform/invertible_augmentations.py
@@ -48,15 +48,17 @@ def get_intensity_augmentations(ndim, aug_name: str = None, aug_dict: dict = Non
         return AugmentationSequential3D(*transforms_list)
 
 
-def get_geometrical_augmentations(ndim, aug_name, p: float = 0.75) -> callable:
+def get_geometrical_augmentations(ndim, aug_name: str = None, aug_dict: dict = None, p: float = 0.75) -> callable:
     assert ndim == 2 or ndim == 3, f"Number of dimensions must be 2 or 3, got ndim={ndim}"
+    assert aug_name is not None or aug_dict is not None, "Either aug_name or aug_dict must be provided."
 
-    if aug_name == "weak":
-        aug_dict = DEFAULT_WEAK_AUGMENTATIONS["geometrical"]
-    elif aug_name == "strong":
-        aug_dict = DEFAULT_STRONG_AUGMENTATIONS["geometrical"]
-    else:
-        raise ValueError(f"Augmentation name needs to be \"weak\" or \"strong\", got aug_name={aug_name}")
+    if aug_dict is None:
+        if aug_name == "weak":
+            aug_dict = DEFAULT_WEAK_AUGMENTATIONS["geometrical"]
+        elif aug_name == "strong":
+            aug_dict = DEFAULT_STRONG_AUGMENTATIONS["geometrical"]
+        else:
+            raise ValueError(f"Augmentation name needs to be \"weak\" or \"strong\", got aug_name={aug_name}")
 
     transforms_list = []
     for trafo, kwargs in aug_dict.items():
@@ -69,7 +71,7 @@ def get_geometrical_augmentations(ndim, aug_name, p: float = 0.75) -> callable:
         return AugmentationSequential3D(*transforms_list)
 
 
-def get_augmentations(aug_name: str, ndim: int, p: float = 0.75):
+def get_default_augmentations(aug_name: str, ndim: int, p: float = 0.75):
     assert ndim == 2 or ndim == 3, f"Number of dimensions must be 2 or 3, got ndim={ndim}"
 
     if aug_name == "weak":
@@ -171,8 +173,8 @@ class MeanTeacherAugmenters:
         student=None,
         clip_max=None,
     ):
-        self.teacher = teacher or InvertibleAugmenter(*get_augmentations("weak", ndim=ndim), clip_max=clip_max)
-        self.student = student or InvertibleAugmenter(*get_augmentations("weak", ndim=ndim), clip_max=clip_max)
+        self.teacher = teacher or InvertibleAugmenter(*get_default_augmentations("weak", ndim=ndim), clip_max=clip_max)
+        self.student = student or InvertibleAugmenter(*get_default_augmentations("weak", ndim=ndim), clip_max=clip_max)
 
     def reset_all(self):
         self.teacher.reset()
@@ -187,8 +189,8 @@ class FixMatchAugmenters:
         student=None,
         clip_max=None,
     ):
-        self.teacher = teacher or InvertibleAugmenter(*get_augmentations("weak", ndim=ndim), clip_max=clip_max)
-        self.student = student or InvertibleAugmenter(*get_augmentations("strong", ndim=ndim), clip_max=clip_max)
+        self.teacher = teacher or InvertibleAugmenter(*get_default_augmentations("weak", ndim=ndim), clip_max=clip_max)
+        self.student = student or InvertibleAugmenter(*get_default_augmentations("strong", ndim=ndim), clip_max=clip_max)
 
     def reset_all(self):
         self.teacher.reset()
@@ -204,9 +206,9 @@ class UniMatchv2Augmenters:
         strong2=None,
         clip_max=None,
     ):
-        self.weak = weak or InvertibleAugmenter(*get_augmentations("weak", ndim=ndim), clip_max=clip_max)
-        self.strong1 = strong1 or InvertibleAugmenter(*get_augmentations("strong", ndim=ndim), clip_max=clip_max)
-        self.strong2 = strong2 or InvertibleAugmenter(*get_augmentations("strong", ndim=ndim), clip_max=clip_max)
+        self.weak = weak or InvertibleAugmenter(*get_default_augmentations("weak", ndim=ndim), clip_max=clip_max)
+        self.strong1 = strong1 or InvertibleAugmenter(*get_default_augmentations("strong", ndim=ndim), clip_max=clip_max)
+        self.strong2 = strong2 or InvertibleAugmenter(*get_default_augmentations("strong", ndim=ndim), clip_max=clip_max)
 
     def reset_all(self):
         self.weak.reset()

--- a/torch_em/transform/invertible_augmentations.py
+++ b/torch_em/transform/invertible_augmentations.py
@@ -25,13 +25,17 @@ DEFAULT_STRONG_AUGMENTATIONS = {
 }
 
 
-def get_intensity_augmentations(aug_name, ndim, p: float = 0.75) -> callable:
-    if aug_name == "weak":
-        aug_dict = DEFAULT_WEAK_AUGMENTATIONS["intensity"]
-    elif aug_name == "strong":
-        aug_dict = DEFAULT_STRONG_AUGMENTATIONS["intensity"]
-    else:
-        raise ValueError(f"Number of dimensions must be 2 or 3, got ndim={ndim}")
+def get_intensity_augmentations(ndim, aug_name: str = None, aug_dict: dict = None, p: float = 0.75) -> callable:
+    assert ndim == 2 or ndim == 3, f"Number of dimensions must be 2 or 3, got ndim={ndim}"
+    assert aug_name is not None or aug_dict is not None, "Either aug_name or aug_dict must be provided."
+
+    if aug_dict is None:
+        if aug_name == "weak":
+            aug_dict = DEFAULT_WEAK_AUGMENTATIONS["intensity"]
+        elif aug_name == "strong":
+            aug_dict = DEFAULT_STRONG_AUGMENTATIONS["intensity"]
+        else:
+            raise ValueError(f"Augmentation name needs to be \"weak\" or \"strong\", got aug_name={aug_name}")
 
     transforms_list = []
     for trafo, kwargs in aug_dict.items():
@@ -44,13 +48,15 @@ def get_intensity_augmentations(aug_name, ndim, p: float = 0.75) -> callable:
         return AugmentationSequential3D(*transforms_list)
 
 
-def get_geometrical_augmentations(aug_name, ndim, p: float = 0.75) -> callable:
+def get_geometrical_augmentations(ndim, aug_name, p: float = 0.75) -> callable:
+    assert ndim == 2 or ndim == 3, f"Number of dimensions must be 2 or 3, got ndim={ndim}"
+
     if aug_name == "weak":
         aug_dict = DEFAULT_WEAK_AUGMENTATIONS["geometrical"]
     elif aug_name == "strong":
         aug_dict = DEFAULT_STRONG_AUGMENTATIONS["geometrical"]
     else:
-        raise ValueError(f"Number of dimensions must be 2 or 3, got ndim={ndim}")
+        raise ValueError(f"Augmentation name needs to be \"weak\" or \"strong\", got aug_name={aug_name}")
 
     transforms_list = []
     for trafo, kwargs in aug_dict.items():
@@ -64,14 +70,16 @@ def get_geometrical_augmentations(aug_name, ndim, p: float = 0.75) -> callable:
 
 
 def get_augmentations(aug_name: str, ndim: int, p: float = 0.75):
+    assert ndim == 2 or ndim == 3, f"Number of dimensions must be 2 or 3, got ndim={ndim}"
+
     if aug_name == "weak":
-        intensity_transforms = get_intensity_augmentations(aug_name, ndim=ndim, p=p)
-        geometrical_transforms = get_geometrical_augmentations(aug_name, ndim=ndim, p=p)
+        intensity_transforms = get_intensity_augmentations(ndim, aug_name=aug_name, p=p)
+        geometrical_transforms = get_geometrical_augmentations(ndim, aug_name=aug_name, p=p)
     elif aug_name == "strong":
-        intensity_transforms = get_intensity_augmentations(aug_name, ndim=ndim, p=p)
-        geometrical_transforms = get_geometrical_augmentations(aug_name, ndim=ndim, p=p)
+        intensity_transforms = get_intensity_augmentations(ndim, aug_name=aug_name, p=p)
+        geometrical_transforms = get_geometrical_augmentations(ndim, aug_name=aug_name, p=p)
     else:
-        raise ValueError(f"aug_name must be 'weak' or 'strong', got {aug_name}")
+        raise ValueError(f"Augmentation name needs to be \"weak\" or \"strong\", got aug_name={aug_name}")
 
     return intensity_transforms, geometrical_transforms
 


### PR DESCRIPTION
Extends `torch_em/transform/invertible_augmentations.py` with two features, motivated by self-training experiments where intensity augmentations could push images out of their valid range and where custom augmentation dictionaries were needed.
  
  ## Changes
  
  ### Intensity clipping (`clip_max`)
  - `InvertibleAugmenter` gains a `clip_max` argument. When set, the augmented image is clamped to `[0.0, clip_max]` after the intensity transforms (before the geometrical transforms), keeping it in range.
  - `clip_max` is plumbed through `MeanTeacherAugmenters`, `FixMatchAugmenters`, and `UniMatchv2Augmenters`, which forward it to their `InvertibleAugmenter` instances. Defaults to `None` (no clipping), so existing behaviour is unchanged.
    
  ### Custom augmentation dictionaries (`aug_dict`)
  - Both `get_intensity_augmentations` and `get_geometrical_augmentations` now accept an explicit `aug_dict`, so callers can pass their own augmentation config instead of only the built-in `"weak"` / `"strong"` presets. Either `aug_name` or `aug_dict` must be provided (enforced by an assertion).
    
  ### Cleanups
  - Added `ndim in (2, 3)` assertions to the augmentation factory functions.
  - Fixed copy-pasted/incorrect error messages (these previously reported a dimension error when the real problem was an invalid augmentation name).
  - Renamed the module-private `get_augmentations` helper to `get_default_augmentations` (distinct from the public `torch_em.transform.get_augmentations`, which is unchanged). All internal call sites were updated.
    
  ## Note
  
  `get_intensity_augmentations` / `get_geometrical_augmentations` now take `ndim` as the first positional argument and accept an optional `aug_dict`. All in-tree callers use keyword arguments and are unaffected; external code that passed arguments positionally would need updating.
