### PR TITLE
Fix mixed-precision trainer compatibility

### DIFF
--- a/torch_em/segmentation.py
+++ b/torch_em/segmentation.py
@@ -484,6 +484,7 @@ def default_segmentation_trainer(
     save_root: Optional[str] = None,
     compile_model: Optional[Union[bool, str]] = None,
     rank: Optional[int] = None,
+    mixed_precision_dtype: Optional[str] = None,
 ):
     """Get a trainer for a segmentation network.
 
@@ -520,7 +521,7 @@ def default_segmentation_trainer(
         learning_rate: The initial learning rate for the AdamW optimizer.
         device: The torch device to use for training. If None, will use a GPU if available.
         log_image_interval: The interval for saving images during logging, in training iterations.
-        mixed_precision: Whether to train with mixed precision.
+        mixed_precision: Whether to train with mixed precision. CPU training uses float32 unless a dtype is set.
         early_stopping: The patience for early stopping in epochs. If None, early stopping will not be used.
         logger: The logger class. Will be instantiated for logging.
             By default uses `torch_em.training.tensorboard_logger.TensorboardLogger`.
@@ -533,6 +534,8 @@ def default_segmentation_trainer(
         save_root: The root folder for saving the checkpoint and logs.
         compile_model: Whether to compile the model before training.
         rank: Rank argument for distributed training. See `torch_em.multi_gpu_training` for details.
+        mixed_precision_dtype: The dtype for autocast in mixed precision training, 'float16' or 'bfloat16'.
+            The GPU default is 'float16'. Set this explicitly to enable CPU mixed precision.
 
     Returns:
         The trainer.
@@ -548,8 +551,7 @@ def default_segmentation_trainer(
     else:
         device = torch.device(device)
 
-    # CPU does not support mixed precision training.
-    if device.type == "cpu":
+    if device.type == "cpu" and mixed_precision_dtype is None:
         mixed_precision = False
 
     return trainer_class(
@@ -563,6 +565,7 @@ def default_segmentation_trainer(
         device=device,
         lr_scheduler=scheduler,
         mixed_precision=mixed_precision,
+        mixed_precision_dtype=mixed_precision_dtype,
         early_stopping=early_stopping,
         log_image_interval=log_image_interval,
         logger=logger,

--- a/torch_em/trainer/default_trainer.py
+++ b/torch_em/trainer/default_trainer.py
@@ -72,8 +72,6 @@ class DefaultTrainer:
         lr_scheduler: The learning rate scheduler.
         log_image_interval: The interval for saving images during logging, in training iterations.
         mixed_precision: Whether to train with mixed precision.
-        mixed_precision_dtype: The dtype for autocast in mixed precision training, 'float16' or 'bfloat16'.
-            The default is 'float16' on the GPU and 'bfloat16' on the CPU. Use 'bfloat16' to avoid overflows.
         early_stopping: The patience for early stopping in epochs. If None, early stopping will not be used.
         logger: The logger class. Will be instantiated for logging.
             By default uses `torch_em.training.tensorboard_logger.TensorboardLogger`.
@@ -82,6 +80,8 @@ class DefaultTrainer:
         save_root: The root folder for saving the checkpoint and logs.
         compile_model: Whether to compile the model before training.
         rank: Rank argument for distributed training. See `torch_em.multi_gpu_training` for details.
+        mixed_precision_dtype: The dtype for autocast in mixed precision training, 'float16' or 'bfloat16'.
+            The default is 'float16' on the GPU and 'bfloat16' on the CPU. Use 'bfloat16' to avoid overflows.
     """
     def __init__(
         self,
@@ -96,7 +96,6 @@ class DefaultTrainer:
         lr_scheduler: Optional[torch.optim.lr_scheduler._LRScheduler] = None,
         log_image_interval: int = 100,
         mixed_precision: bool = True,
-        mixed_precision_dtype: Optional[str] = None,
         early_stopping: Optional[int] = None,
         logger=TensorboardLogger,
         logger_kwargs: Optional[Dict[str, Any]] = None,
@@ -104,6 +103,7 @@ class DefaultTrainer:
         save_root: Optional[str] = None,
         compile_model: Optional[Union[bool, str]] = None,
         rank: Optional[int] = None,
+        mixed_precision_dtype: Optional[str] = None,
     ):
         if name is None and not issubclass(logger, WandbLogger):
             raise TypeError("Name cannot be None if not using the WandbLogger")
@@ -633,8 +633,9 @@ class DefaultTrainer:
         self.model.to(self.device)
 
         self.optimizer.load_state_dict(save_dict["optimizer_state"])
-        if self.scaler is not None:
-            self.scaler.load_state_dict(save_dict["scaler_state"])
+        scaler_state = save_dict.get("scaler_state")
+        if self.scaler is not None and scaler_state:
+            self.scaler.load_state_dict(scaler_state)
         if self.lr_scheduler is not None:
             self.lr_scheduler.load_state_dict(save_dict["scheduler_state"])
 


### PR DESCRIPTION
I was thinking about this yesterday, and got hands on my system today. 

I don't like the idea of `bfloat16` pinned for CPU systems, otherwise the training slows down by a lot for systems which do not support native `bf16` -- `fp32` is still insanely faster for older CPUs (like my Ubuntu system for example).

PS. And CPU users who exclusively want `bf16` can set it in `mixed_precision_type`.

I'll go ahead and merge this!

cc: @chuyaowang made some patch changes here!