### PR TITLE
Add the HASHI invasive breast cancer segmentation dataset

### DIFF
--- a/scripts/datasets/histopathology/check_cytonuke.py
+++ b/scripts/datasets/histopathology/check_cytonuke.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+from torch_em.util.debug import check_loader
+from torch_em.data.datasets import get_cytonuke_loader
+
+
+sys.path.append("..")
+
+
+def check_cytonuke():
+    from util import ROOT
+
+    loader = get_cytonuke_loader(
+        path=os.path.join(ROOT, "cytonuke"),
+        patch_shape=(256, 256),
+        batch_size=2,
+        split="train",
+        annotations="cell",
+        download=True,
+    )
+
+    check_loader(loader, 8, instance_labels=True, rgb=True)
+
+
+if __name__ == "__main__":
+    check_cytonuke()

--- a/scripts/datasets/histopathology/check_hashi.py
+++ b/scripts/datasets/histopathology/check_hashi.py
@@ -1,0 +1,34 @@
+import os
+import argparse
+
+from torch_em.util.debug import check_loader
+from torch_em.data.datasets import get_hashi_loader
+
+
+DEFAULT_ROOT = os.path.join(os.path.dirname(os.path.dirname(__file__)), "data", "hashi")
+
+
+def check_hashi(path, save_path):
+    # Restrict to a handful of CINJ tiles by default: each cohort's images are a multi-GB
+    # archive on Zenodo, and 'sample_ids' picks a shallow subset without touching the rest.
+    loader = get_hashi_loader(
+        path=path,
+        batch_size=1,
+        patch_shape=(512, 512),
+        cohorts="cinj",
+        sample_ids=["10253", "10254", "10255", "10256"],
+        download=True,
+    )
+    check_loader(loader, 4, instance_labels=False, plt=save_path is not None, rgb=True, save_path=save_path)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--path", default=DEFAULT_ROOT, help="Folder for the HASHI data.")
+    parser.add_argument("--save-path", default=None, help="Optional path for a non-interactive loader check.")
+    args = parser.parse_args()
+    check_hashi(args.path, args.save_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/torch_em/data/datasets/histopathology/__init__.py
+++ b/torch_em/data/datasets/histopathology/__init__.py
@@ -13,6 +13,7 @@ from .cytonuke import get_cytonuke_loader, get_cytonuke_dataset
 from .deepliif import get_deepliif_loader, get_deepliif_dataset
 from .glas import get_glas_loader, get_glas_dataset
 from .glysac import get_glysac_loader, get_glysac_dataset
+from .hashi import get_hashi_loader, get_hashi_dataset
 from .hest import get_hest_loader, get_hest_dataset
 from .icc import get_icc_loader, get_icc_dataset
 from .ignite import get_ignite_loader, get_ignite_dataset

--- a/torch_em/data/datasets/histopathology/__init__.py
+++ b/torch_em/data/datasets/histopathology/__init__.py
@@ -9,6 +9,7 @@ from .cpm import get_cpm_loader, get_cpm_dataset
 from .crc_epithelium import get_crc_epithelium_loader, get_crc_epithelium_dataset
 from .cryonuseg import get_cryonuseg_loader, get_cryonuseg_dataset
 from .cytodark0 import get_cytodark0_loader, get_cytodark0_dataset
+from .cytonuke import get_cytonuke_loader, get_cytonuke_dataset
 from .deepliif import get_deepliif_loader, get_deepliif_dataset
 from .glas import get_glas_loader, get_glas_dataset
 from .glysac import get_glysac_loader, get_glysac_dataset

--- a/torch_em/data/datasets/histopathology/cytonuke.py
+++ b/torch_em/data/datasets/histopathology/cytonuke.py
@@ -1,0 +1,228 @@
+"""The CytoNuke dataset contains annotations for nucleus and whole-cell segmentation
+in H&E stained bright-field histopathology images of head and neck squamous cell
+carcinoma. The images are re-distributed crops from the CPTAC-HNSCC collection.
+
+This dataset is located at https://zenodo.org/records/10560728.
+This dataset is from the publication https://doi.org/10.1016/j.cmpb.2024.108215.
+Please cite it if you use this dataset for your research.
+"""
+
+import os
+from tqdm import tqdm
+from natsort import natsorted
+from typing import Union, Literal, Tuple, List
+
+import json
+import numpy as np
+import pandas as pd
+import imageio.v3 as imageio
+from skimage.draw import polygon as sk_polygon
+from skimage.segmentation import relabel_sequential
+from sklearn.model_selection import train_test_split
+
+from torch.utils.data import Dataset, DataLoader
+
+import torch_em
+
+from .. import util
+
+
+URL = "https://zenodo.org/records/10560728/files/CytoNuke%20Dataset.zip"
+CHECKSUM = "834836444fe749cc48daa7557458ba578bc00306a59286896e3d29666e98777a"
+
+CATEGORY_IDS = {"nuclei": 0, "cell": 1}
+
+
+def _annotations_to_instances(coco, image_metadata, category_id):
+    height, width = image_metadata["height"], image_metadata["width"]
+    seg = np.zeros((height, width), dtype="uint32")
+
+    annotations = [a for a in coco["annotations"] if a["image_id"] == image_metadata["id"]]
+    annotations = [a for a in annotations if a["category_id"] == category_id]
+
+    for seg_id, annotation in enumerate(annotations, 1):
+        for polygon in annotation["segmentation"]:
+            xs, ys = polygon[0::2], polygon[1::2]
+            rr, cc = sk_polygon(ys, xs, shape=(height, width))
+            seg[rr, cc] = seg_id
+
+    seg, _, _ = relabel_sequential(seg)
+    return seg.astype("uint16")
+
+
+def _create_segmentations_from_annotations(data_dir, annotations):
+    image_dir = os.path.join(data_dir, "images")
+    seg_dir = os.path.join(data_dir, "labels", annotations)
+    os.makedirs(seg_dir, exist_ok=True)
+
+    with open(os.path.join(data_dir, "coco.json")) as f:
+        coco = json.load(f)
+
+    category_id = CATEGORY_IDS[annotations]
+
+    image_paths, seg_paths = [], []
+    for image_metadata in tqdm(coco["images"], desc=f"Creating '{annotations}' segmentations from coco annotations"):
+        file_name = image_metadata["file_name"]
+        image_path = os.path.join(image_dir, file_name)
+        assert os.path.exists(image_path), image_path
+        image_paths.append(image_path)
+
+        seg_path = os.path.join(seg_dir, file_name.replace(".png", ".tif"))
+        seg_paths.append(seg_path)
+        if os.path.exists(seg_path):
+            continue
+
+        seg = _annotations_to_instances(coco, image_metadata, category_id)
+        imageio.imwrite(seg_path, seg, compression="zlib")
+
+    return natsorted(image_paths), natsorted(seg_paths)
+
+
+def _create_split_csv(path, image_paths):
+    csv_path = os.path.join(path, "cytonuke_split.csv")
+    if os.path.exists(csv_path):
+        df = pd.read_csv(csv_path)
+        return {split: json.loads(df.iloc[0][split].replace("'", '"')) for split in ("train", "val", "test")}
+
+    print(f"Creating a new split file at '{csv_path}'.")
+    image_ids = natsorted(os.path.basename(p) for p in image_paths)
+
+    train_ids, test_ids = train_test_split(image_ids, test_size=0.2, random_state=42)
+    train_ids, val_ids = train_test_split(train_ids, test_size=0.15, random_state=42)
+    split_ids = {"train": train_ids, "val": val_ids, "test": test_ids}
+
+    df = pd.DataFrame.from_dict([split_ids])
+    df.to_csv(csv_path, index=False)
+
+    return split_ids
+
+
+def get_cytonuke_data(path: Union[os.PathLike, str], download: bool = False) -> str:
+    """Download the CytoNuke data.
+
+    Args:
+        path: Filepath to a folder where the downloaded data will be saved.
+        download: Whether to download the data if it is not present.
+
+    Returns:
+        Filepath where the dataset is downloaded and stored for further preprocessing.
+    """
+    data_dir = os.path.join(path, "data")
+    if os.path.exists(data_dir):
+        return data_dir
+
+    os.makedirs(path, exist_ok=True)
+    zip_path = os.path.join(path, "cytonuke.zip")
+    util.download_source(path=zip_path, url=URL, download=download, checksum=CHECKSUM)
+    util.unzip(zip_path=zip_path, dst=data_dir)
+
+    return data_dir
+
+
+def get_cytonuke_paths(
+    path: Union[os.PathLike, str],
+    split: Literal["train", "val", "test"],
+    annotations: Literal["nuclei", "cell"] = "cell",
+    download: bool = False,
+) -> Tuple[List[str], List[str]]:
+    """Get paths to the CytoNuke data.
+
+    NOTE: The source publishes no official split, so this function creates and stores a
+    deterministic split (65% train, 15% val, 20% test) the first time it is called.
+
+    Args:
+        path: Filepath to a folder where the downloaded data will be saved.
+        split: The choice of data split.
+        annotations: The choice of annotations.
+        download: Whether to download the data if it is not present.
+
+    Returns:
+        List of filepaths to the image data.
+        List of filepaths to the label data.
+    """
+    if annotations not in CATEGORY_IDS:
+        raise ValueError(f"'{annotations}' is not a valid annotation choice.")
+
+    data_dir = get_cytonuke_data(path, download)
+    image_paths, seg_paths = _create_segmentations_from_annotations(data_dir, annotations)
+
+    split_ids = _create_split_csv(path, image_paths)[split]
+    raw_paths = [p for p in image_paths if os.path.basename(p) in split_ids]
+    label_paths = [p for p in seg_paths if os.path.basename(p).replace(".tif", ".png") in split_ids]
+
+    assert len(raw_paths) == len(label_paths) and len(raw_paths) > 0
+    return raw_paths, label_paths
+
+
+def get_cytonuke_dataset(
+    path: Union[os.PathLike, str],
+    patch_shape: Tuple[int, int],
+    split: Literal["train", "val", "test"],
+    annotations: Literal["nuclei", "cell"] = "cell",
+    resize_inputs: bool = False,
+    download: bool = False,
+    **kwargs
+) -> Dataset:
+    """Get the CytoNuke dataset for nucleus and whole-cell segmentation.
+
+    Args:
+        path: Filepath to a folder where the downloaded data will be saved.
+        patch_shape: The patch shape to use for training.
+        split: The choice of data split.
+        annotations: The choice of annotations.
+        resize_inputs: Whether to resize the inputs.
+        download: Whether to download the data if it is not present.
+        kwargs: Additional keyword arguments for `torch_em.default_segmentation_dataset`.
+
+    Returns:
+        The segmentation dataset.
+    """
+    raw_paths, label_paths = get_cytonuke_paths(path, split, annotations, download)
+
+    if resize_inputs:
+        resize_kwargs = {"patch_shape": patch_shape, "is_rgb": True}
+        kwargs, patch_shape = util.update_kwargs_for_resize_trafo(
+            kwargs=kwargs, patch_shape=patch_shape, resize_inputs=resize_inputs, resize_kwargs=resize_kwargs
+        )
+
+    return torch_em.default_segmentation_dataset(
+        raw_paths=raw_paths,
+        raw_key=None,
+        label_paths=label_paths,
+        label_key=None,
+        is_seg_dataset=False,
+        patch_shape=patch_shape,
+        with_channels=True,
+        ndim=2,
+        **kwargs
+    )
+
+
+def get_cytonuke_loader(
+    path: Union[os.PathLike, str],
+    batch_size: int,
+    patch_shape: Tuple[int, int],
+    split: Literal["train", "val", "test"],
+    annotations: Literal["nuclei", "cell"] = "cell",
+    resize_inputs: bool = False,
+    download: bool = False,
+    **kwargs
+) -> DataLoader:
+    """Get the CytoNuke dataloader for nucleus and whole-cell segmentation.
+
+    Args:
+        path: Filepath to a folder where the downloaded data will be saved.
+        batch_size: The batch size for training.
+        patch_shape: The patch shape to use for training.
+        split: The choice of data split.
+        annotations: The choice of annotations.
+        resize_inputs: Whether to resize the inputs.
+        download: Whether to download the data if it is not present.
+        kwargs: Additional keyword arguments for `torch_em.default_segmentation_dataset` or for the PyTorch DataLoader.
+
+    Returns:
+        The DataLoader.
+    """
+    ds_kwargs, loader_kwargs = util.split_kwargs(torch_em.default_segmentation_dataset, **kwargs)
+    dataset = get_cytonuke_dataset(path, patch_shape, split, annotations, resize_inputs, download, **ds_kwargs)
+    return torch_em.get_data_loader(dataset, batch_size, **loader_kwargs)

--- a/torch_em/data/datasets/histopathology/hashi.py
+++ b/torch_em/data/datasets/histopathology/hashi.py
@@ -1,0 +1,374 @@
+"""This dataset contains annotations for invasive breast cancer region segmentation
+in H&E-stained whole-slide histopathology tiles from four institutions.
+
+The data is from the publication https://doi.org/10.1371/journal.pone.0196828
+("High-throughput adaptive sampling for whole-slide histopathology image analysis
+(HASHI) via convolutional neural networks: application to invasive breast cancer
+detection"). It is hosted on Zenodo at https://zenodo.org/records/4993672 under a
+CC0-1.0 license. Please cite the publication if you use this dataset in your research.
+
+The dataset covers four cohorts: HUP and UHCMC/CWRU (used for training in the
+publication), and CINJ and TCGA (held out for testing). Three pathologists manually
+delineated invasive cancer regions at 2x magnification. Mask label values: 0
+(background) and 1 (invasive cancer region).
+
+NOTE: Each cohort's images and masks are stored in separate multi-slide zip archives
+on Zenodo. To avoid downloading a whole archive for a subset of its slides, each
+raw/mask pair is fetched as a single zip member via an HTTP range request. Raw tiles
+and their masks can differ by a 1px margin on each axis; each pair is cropped to their
+shared shape on first download.
+"""
+
+import os
+import time
+import struct
+import zlib
+import zipfile
+from glob import glob
+from natsort import natsorted
+from typing import List, Literal, Optional, Tuple, Union
+
+from tqdm import tqdm
+
+import imageio.v3 as imageio
+
+import requests
+
+from torch.utils.data import Dataset, DataLoader
+
+import torch_em
+
+from .. import util
+
+
+RECORD_URL = "https://zenodo.org/api/records/4993672/files"
+N_RETRIES = 5
+
+COHORTS = {
+    "hup": {"imgs": ["HUP_imgs_idx5_Part1.zip", "HUP_imgs_idx5_Part2.zip"], "masks": "HUP_masks.zip"},
+    "cwru": {"imgs": ["CWRU_imgs_idx8.zip"], "masks": "CWRU_masks.zip"},
+    "cinj": {"imgs": ["CINJ_imgs_idx5.zip"], "masks": "CINJ_masks_HG.zip"},
+    "tcga": {"imgs": ["TCGA_imgs_idx5.zip"], "masks": "TCGA_masks.zip"},
+}
+
+CHECKSUMS = {  # md5 of the full Zenodo archives, kept for provenance
+    "HUP_imgs_idx5_Part1.zip": "c1bdaeb3c5bd2cd657b0081b9f52e3fe",
+    "HUP_imgs_idx5_Part2.zip": "3127ee09f1752b76edd8d16383c52d30",
+    "HUP_masks.zip": "6785a4cc69eae45217eb3e39843e3465",
+    "CWRU_imgs_idx8.zip": "b1d13b2ecec81c0efe877bb25f45ece1",
+    "CWRU_masks.zip": "a83e46a69d99c8e88ba5beef3be654a9",
+    "CINJ_imgs_idx5.zip": "76dd6dc6f2e78bacdec427d0bd0d8740",
+    "CINJ_masks_HG.zip": "65ab52631acaa40085972d1946ed1924",
+    "TCGA_imgs_idx5.zip": "cc62330b4a2421219bd38f958e901c13",
+    "TCGA_masks.zip": "a48c5c04c93d01831dc4a89a4dba609a",
+}
+
+# HUP and CINJ raw tiles are named '{id}_idx5.png', with masks named differently.
+# CWRU and TCGA raw tiles and masks share the exact same filename.
+MASK_SUFFIX = {"hup": "_annotation_mask.png", "cinj": ".png"}
+SPLITS = {"train": ["hup", "cwru"], "test": ["cinj", "tcga"]}
+
+
+def _get_with_retries(url, **kwargs):
+    # The Zenodo API gateway occasionally times out under range requests; retry with backoff.
+    for attempt in range(N_RETRIES):
+        try:
+            r = requests.get(url, timeout=60, **kwargs)
+            r.raise_for_status()
+            return r
+        except (requests.exceptions.RequestException,) as error:
+            if attempt == N_RETRIES - 1:
+                raise error
+            time.sleep(2 ** attempt)
+
+
+class _RemoteZipReader:
+    """Seekable file-like object over a remote zip, for reading its (small) structural data."""
+
+    def __init__(self, url, size):
+        self.url = url
+        self.size = size
+        self.pos = 0
+
+    def seek(self, offset, whence=0):
+        if whence == 0:
+            self.pos = offset
+        elif whence == 1:
+            self.pos += offset
+        elif whence == 2:
+            self.pos = self.size + offset
+        return self.pos
+
+    def tell(self):
+        return self.pos
+
+    def read(self, n=-1):
+        end = self.size - 1 if n is None or n < 0 else min(self.pos + n, self.size) - 1
+        if end < self.pos:
+            return b""
+        r = _get_with_retries(self.url, headers={"Range": f"bytes={self.pos}-{end}"})
+        data = r.content
+        self.pos += len(data)
+        return data
+
+    def readable(self):
+        return True
+
+    def seekable(self):
+        return True
+
+
+def _remote_size(url):
+    # A HEAD request fails on this host's presigned redirect target, which is only signed for GET.
+    r = _get_with_retries(url, stream=True, allow_redirects=True)
+    return int(r.headers["Content-Length"])
+
+
+def _list_zip_index(url):
+    """List a remote zip's central directory once, so individual members can be fetched by offset."""
+    size = _remote_size(url)
+    zf = zipfile.ZipFile(_RemoteZipReader(url, size))
+    return size, {info.filename: info for info in zf.infolist()}
+
+
+def _fetch_zip_member(url, size, info, dst_path):
+    if os.path.exists(dst_path):
+        return
+
+    # Fetch the local file header (with headroom for its variable-length fields) and the compressed
+    # payload in one range request. This dataset's members carry short names and no extra fields, so
+    # 256 bytes of headroom is always enough.
+    start = info.header_offset
+    end = start + 256 + info.compress_size - 1
+    r = _get_with_retries(url, headers={"Range": f"bytes={start}-{end}"})
+    buf = r.content
+
+    fn_len, extra_len = struct.unpack("<HH", buf[26:30])
+    data_start = 30 + fn_len + extra_len
+    compressed = buf[data_start:data_start + info.compress_size]
+    if len(compressed) != info.compress_size:
+        raise RuntimeError(f"Incomplete read for zip member '{info.filename}'.")
+
+    data = compressed if info.compress_type == zipfile.ZIP_STORED else zlib.decompressobj(-15).decompress(compressed)
+
+    os.makedirs(os.path.dirname(dst_path), exist_ok=True)
+    tmp_path = dst_path + ".tmp"
+    with open(tmp_path, "wb") as f:
+        f.write(data)
+    os.replace(tmp_path, dst_path)
+
+
+def _align_pair(img_path, mask_path):
+    """Crop a raw tile and its mask to their shared shape, in case they differ by a small margin."""
+    image = imageio.imread(img_path)
+    mask = imageio.imread(mask_path)
+    height, width = min(image.shape[0], mask.shape[0]), min(image.shape[1], mask.shape[1])
+    if image.shape[:2] != (height, width):
+        imageio.imwrite(img_path, image[:height, :width])
+    if mask.shape[:2] != (height, width):
+        imageio.imwrite(mask_path, mask[:height, :width])
+
+
+def _image_key(cohort, basename):
+    return basename[:-len("_idx5.png")] if cohort in MASK_SUFFIX else basename
+
+
+def _mask_key(cohort, basename):
+    suffix = MASK_SUFFIX.get(cohort)
+    return basename[:-len(suffix)] if suffix else basename
+
+
+def _resolve_cohorts(cohorts):
+    if cohorts is None:
+        return list(COHORTS)
+    if isinstance(cohorts, str):
+        cohorts = [cohorts]
+    invalid = set(cohorts) - set(COHORTS)
+    if invalid:
+        raise ValueError(f"Invalid cohort choices: {sorted(invalid)}. Choose from {sorted(COHORTS)}.")
+    return cohorts
+
+
+def get_hashi_data(
+    path: Union[os.PathLike, str],
+    cohorts: Optional[Union[str, List[str]]] = None,
+    sample_ids: Optional[List[str]] = None,
+    download: bool = False,
+) -> str:
+    """Download the HASHI invasive breast cancer segmentation data.
+
+    Args:
+        path: Filepath to a folder where the downloaded data will be saved.
+        cohorts: The cohort(s) to download. By default all four cohorts are downloaded.
+        sample_ids: The tile ids to restrict the data to. By default all tiles are used.
+        download: Whether to download the data if it is not present.
+
+    Returns:
+        Filepath to the folder where the raw images and masks are stored.
+    """
+    cohorts = _resolve_cohorts(cohorts)
+    path = str(path)
+    os.makedirs(path, exist_ok=True)
+
+    for cohort in cohorts:
+        masks_url = f"{RECORD_URL}/{COHORTS[cohort]['masks']}/content"
+        masks_size, masks_index = _list_zip_index(masks_url)
+        mask_by_key = {
+            _mask_key(cohort, name.rsplit("/", 1)[-1]): name
+            for name in masks_index if name.lower().endswith(".png")
+        }
+
+        for imgs_zip in COHORTS[cohort]["imgs"]:
+            imgs_url = f"{RECORD_URL}/{imgs_zip}/content"
+            imgs_size, imgs_index = _list_zip_index(imgs_url)
+            img_members = sorted(name for name in imgs_index if name.lower().endswith(".png"))
+
+            for img_name in tqdm(img_members, desc=f"Fetch {cohort} tiles ({imgs_zip})"):
+                basename = img_name.rsplit("/", 1)[-1]
+                key = _image_key(cohort, basename)
+                if sample_ids is not None and key not in sample_ids:
+                    continue
+                if key not in mask_by_key:
+                    raise RuntimeError(f"Missing mask for raw image '{img_name}' in cohort '{cohort}'.")
+                mask_name = mask_by_key[key]
+
+                img_path = os.path.join(path, cohort, "images", basename)
+                mask_path = os.path.join(path, cohort, "masks", mask_name.rsplit("/", 1)[-1])
+                if os.path.exists(img_path) and os.path.exists(mask_path):
+                    continue
+                if not download:
+                    raise RuntimeError(f"Data for cohort '{cohort}' is not found and download is set to False.")
+
+                _fetch_zip_member(imgs_url, imgs_size, imgs_index[img_name], img_path)
+                _fetch_zip_member(masks_url, masks_size, masks_index[mask_name], mask_path)
+                _align_pair(img_path, mask_path)
+
+    return path
+
+
+def get_hashi_paths(
+    path: Union[os.PathLike, str],
+    cohorts: Optional[Union[str, List[str]]] = None,
+    split: Optional[Literal["train", "test"]] = None,
+    sample_ids: Optional[List[str]] = None,
+    download: bool = False,
+) -> Tuple[List[str], List[str]]:
+    """Get paths to the HASHI invasive breast cancer segmentation images and masks.
+
+    Args:
+        path: Filepath to a folder where the downloaded data will be saved.
+        cohorts: The cohort(s) to use. By default all four cohorts are used.
+        split: The documented train ('hup', 'cwru') / test ('cinj', 'tcga') split. By default both are used.
+        sample_ids: The tile ids to restrict the data to. By default all tiles are used.
+        download: Whether to download the data if it is not present.
+
+    Returns:
+        List of filepaths for the image data.
+        List of filepaths for the label data.
+    """
+    cohorts = _resolve_cohorts(cohorts)
+    if split is not None:
+        cohorts = [cohort for cohort in cohorts if cohort in SPLITS[split]]
+
+    data_dir = get_hashi_data(path, cohorts, sample_ids, download)
+
+    raw_paths, label_paths = [], []
+    for cohort in cohorts:
+        img_paths = natsorted(glob(os.path.join(data_dir, cohort, "images", "*.png")))
+        mask_dir = os.path.join(data_dir, cohort, "masks")
+        mask_by_key = {_mask_key(cohort, name): name for name in os.listdir(mask_dir)}
+
+        for img_path in img_paths:
+            basename = os.path.basename(img_path)
+            key = _image_key(cohort, basename)
+            if sample_ids is not None and key not in sample_ids:
+                continue
+            if key not in mask_by_key:
+                raise RuntimeError(f"Missing mask for raw image '{img_path}' in cohort '{cohort}'.")
+            raw_paths.append(img_path)
+            label_paths.append(os.path.join(mask_dir, mask_by_key[key]))
+
+    if not raw_paths:
+        raise RuntimeError("Could not find any images and masks for the requested settings.")
+
+    return raw_paths, label_paths
+
+
+def get_hashi_dataset(
+    path: Union[os.PathLike, str],
+    patch_shape: Tuple[int, int],
+    cohorts: Optional[Union[str, List[str]]] = None,
+    split: Optional[Literal["train", "test"]] = None,
+    sample_ids: Optional[List[str]] = None,
+    resize_inputs: bool = False,
+    download: bool = False,
+    **kwargs,
+) -> Dataset:
+    """Get the HASHI dataset for invasive breast cancer region segmentation.
+
+    Args:
+        path: Filepath to a folder where the downloaded data will be saved.
+        patch_shape: The patch shape to use for training.
+        cohorts: The cohort(s) to use. By default all four cohorts are used.
+        split: The documented train ('hup', 'cwru') / test ('cinj', 'tcga') split. By default both are used.
+        sample_ids: The tile ids to restrict the data to. By default all tiles are used.
+        resize_inputs: Whether to resize the inputs.
+        download: Whether to download the data if it is not present.
+        kwargs: Additional keyword arguments for `torch_em.default_segmentation_dataset`.
+
+    Returns:
+        The segmentation dataset.
+    """
+    raw_paths, label_paths = get_hashi_paths(path, cohorts, split, sample_ids, download)
+
+    if resize_inputs:
+        resize_kwargs = {"patch_shape": patch_shape, "is_rgb": True}
+        kwargs, patch_shape = util.update_kwargs_for_resize_trafo(
+            kwargs=kwargs, patch_shape=patch_shape, resize_inputs=resize_inputs, resize_kwargs=resize_kwargs
+        )
+
+    return torch_em.default_segmentation_dataset(
+        raw_paths=raw_paths,
+        raw_key=None,
+        label_paths=label_paths,
+        label_key=None,
+        patch_shape=patch_shape,
+        is_seg_dataset=False,
+        ndim=2,
+        with_channels=True,
+        **kwargs,
+    )
+
+
+def get_hashi_loader(
+    path: Union[os.PathLike, str],
+    batch_size: int,
+    patch_shape: Tuple[int, int],
+    cohorts: Optional[Union[str, List[str]]] = None,
+    split: Optional[Literal["train", "test"]] = None,
+    sample_ids: Optional[List[str]] = None,
+    resize_inputs: bool = False,
+    download: bool = False,
+    **kwargs,
+) -> DataLoader:
+    """Get the HASHI dataloader for invasive breast cancer region segmentation.
+
+    Args:
+        path: Filepath to a folder where the downloaded data will be saved.
+        batch_size: The batch size for training.
+        patch_shape: The patch shape to use for training.
+        cohorts: The cohort(s) to use. By default all four cohorts are used.
+        split: The documented train ('hup', 'cwru') / test ('cinj', 'tcga') split. By default both are used.
+        sample_ids: The tile ids to restrict the data to. By default all tiles are used.
+        resize_inputs: Whether to resize the inputs.
+        download: Whether to download the data if it is not present.
+        kwargs: Additional keyword arguments for `torch_em.default_segmentation_dataset` or the PyTorch DataLoader.
+
+    Returns:
+        The DataLoader.
+    """
+    ds_kwargs, loader_kwargs = util.split_kwargs(torch_em.default_segmentation_dataset, **kwargs)
+    dataset = get_hashi_dataset(
+        path, patch_shape, cohorts, split, sample_ids, resize_inputs, download, **ds_kwargs
+    )
+    return torch_em.get_data_loader(dataset, batch_size, **loader_kwargs)


### PR DESCRIPTION
Adds a loader for the HASHI dataset (Cruz-Roa et al., PLOS ONE 2018): H&E-stained 2D whole-slide histopathology tiles from four institutions (HUP, CWRU, CINJ, TCGA), hosted on Zenodo under CC0. Each tile ships a paired binary segmentation mask of invasive breast cancer regions, delineated by pathologists. The loader fetches raw/mask pairs from the per-cohort Zenodo archives via HTTP range requests and supports the paper's documented train (HUP, CWRU) / test (CINJ, TCGA) split.